### PR TITLE
feat: add replacement for cpx

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -19,3 +19,4 @@ ESLint plugin.
 - [`MaterializeCSS`](./materialize-css.md)
 - [`moment.js`](./momentjs.md)
 - [`npm-run-all`](./npm-run-all.md)
+- [`cpx`](./cpx.md)

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -12,6 +12,7 @@ ESLint plugin.
 
 ## List of modules
 
+- [`cpx`](./cpx.md)
 - [`eslint-plugin-import`](./eslint-plugin-import.md)
 - [`eslint-plugin-node`](./eslint-plugin-node.md)
 - [`eslint-plugin-react`](./eslint-plugin-react.md)
@@ -19,4 +20,3 @@ ESLint plugin.
 - [`MaterializeCSS`](./materialize-css.md)
 - [`moment.js`](./momentjs.md)
 - [`npm-run-all`](./npm-run-all.md)
-- [`cpx`](./cpx.md)

--- a/docs/modules/cpx.md
+++ b/docs/modules/cpx.md
@@ -1,0 +1,16 @@
+# cpx
+
+`cpx` is no longer maintained. A maintenance fork is actively maintained.
+
+# Alternatives
+
+## cpx2
+
+Copy file globs, watching for changes.
+
+This module provides a CLI tool like cp, but with watching.
+
+This is a maintained fork of [mysticatea/cpx](https://github.com/mysticatea/cpx). It retains the `cpx` bin name, so it can act as a drop-in replacement.
+
+[Project Page](https://github.com/bcomnes/cpx2)
+[NPM](https://www.npmjs.com/package/cpx2)


### PR DESCRIPTION
# Summary

Add replacement for `cpx`, similar to what I did in https://github.com/renovatebot/renovate/pull/27507. Closes https://github.com/es-tooling/module-replacements/issues/18.