### PR TITLE
feat: replacements for mkdirp and rimraf

### DIFF
--- a/docs/modules/mkdirp.md
+++ b/docs/modules/mkdirp.md
@@ -1,0 +1,19 @@
+# mkdirp
+
+`mkdirp` can often be replaced with built-in Node APIs.
+
+# Alternatives
+
+## NodeJS (since v10.x)
+
+Node.js v10.0 and up supports the `recursive` option in [the `fs.mkdir`
+function](https://nodejs.org/api/fs.html#fspromisesmkdirpath-options), which
+allows parent directories to be created automatically:
+
+```js
+import {mkdir} from 'node:fs/promises';
+import {mkdirSync} from 'node:fs';
+
+await mkdir('some/nested/path', {recursive: true});
+mkdirSync('some/nested/path', {recursive: true});
+```

--- a/docs/modules/rimraf.md
+++ b/docs/modules/rimraf.md
@@ -35,3 +35,11 @@ async function main() {
 rmdirSync(path, {recursive: true});
 
 ```
+
+For command-line usage, such as npm scripts, you can run Node in eval mode:
+```bash
+node -e "fs.rmSync('./foo', { recursive: true, force: true })"
+```
+Note that this may not work for developers who use alternative JavaScript
+runtimes and do not have Node installed. To support them, you can use the
+[premove](https://www.npmjs.com/package/premove) package instead.

--- a/docs/modules/rimraf.md
+++ b/docs/modules/rimraf.md
@@ -12,16 +12,16 @@ function](https://nodejs.org/api/fs.html#fspromisesrmpath-options), which allows
 files and directories to be deleted recursively:
 
 ```js
-import {rm} from 'node:fs/promises';
-import {rmSync} from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { rmSync } from 'node:fs';
 
 // This will throw an error if the path does not exist.
-await rm(path, {recursive: true});
-rmSync(path, {recursive: true});
+await rm(path, { recursive: true });
+rmSync(path, { recursive: true });
 
 // This will do nothing if the path does not exist.
-await rm(path, {recursive: true, force: true});
-rmSync(path, {recursive: true, force: true});
+await rm(path, { recursive: true, force: true });
+rmSync(path, { recursive: true, force: true });
 ```
 
 If you need to support Node 12, you can [use
@@ -30,14 +30,14 @@ also has the `recursive` option available since Node v12.10, although it will
 print a deprecation message in Node v14 and up:
 
 ```js
-const {rmdir} = require('fs').promises;
-const {rmdirSync} = require('fs');
+const { rmdir } = require('fs').promises;
+const { rmdirSync } = require('fs');
 
 async function main() {
-    await rmdir(path, {recursive: true});
+    await rmdir(path, { recursive: true });
 }
 
-rmdirSync(path, {recursive: true});
+rmdirSync(path, { recursive: true });
 
 ```
 

--- a/docs/modules/rimraf.md
+++ b/docs/modules/rimraf.md
@@ -1,0 +1,37 @@
+# rimraf
+
+`rimraf` pulls in many transitive dependencies, and can often be replaced with
+built-in Node APIs.
+
+# Alternatives
+
+## NodeJS (since v12.x / v14.x)
+
+Node.js v14.14 and up supports [the `fs.rm`
+function](https://nodejs.org/api/fs.html#fspromisesrmpath-options), which allows
+files and directories to be deleted recursively:
+
+```js
+import {rm} from 'node:fs/promises';
+import {rmSync} from 'node:fs';
+
+await rm(path, {recursive: true});
+rmSync(path, {recursive: true});
+```
+
+If you need to support Node 12, you can [use
+`fs.rmdir`](https://nodejs.org/api/fs.html#fspromisesrmdirpath-options), which
+also has the `recursive` option available since Node v12.10, although it will
+print a deprecation message in Node v14 and up:
+
+```js
+const {rmdir} = require('fs').promises;
+const {rmdirSync} = require('fs');
+
+async function main() {
+    await rmdir(path, {recursive: true});
+}
+
+rmdirSync(path, {recursive: true});
+
+```

--- a/docs/modules/rimraf.md
+++ b/docs/modules/rimraf.md
@@ -45,6 +45,11 @@ For command-line usage, such as npm scripts, you can run Node in eval mode:
 ```bash
 node -e "fs.rmSync('./foo', { recursive: true, force: true })"
 ```
-Note that this may not work for developers who use alternative JavaScript
-runtimes and do not have Node installed. To support them, you can use the
-[premove](https://www.npmjs.com/package/premove) package instead.
+
+## premove (Node 8.x and up)
+
+For command-line usage across runtimes (to support developers who use
+alternative runtimes and may not have the `node` command available), the
+[`premove`](https://www.npmjs.com/package/premove) package includes a CLI.
+
+`premove` also supports older versions of Node (v8.x and up) than `fs.rm` does.

--- a/docs/modules/rimraf.md
+++ b/docs/modules/rimraf.md
@@ -15,8 +15,13 @@ files and directories to be deleted recursively:
 import {rm} from 'node:fs/promises';
 import {rmSync} from 'node:fs';
 
+// This will throw an error if the path does not exist.
 await rm(path, {recursive: true});
 rmSync(path, {recursive: true});
+
+// This will do nothing if the path does not exist.
+await rm(path, {recursive: true, force: true});
+rmSync(path, {recursive: true, force: true});
 ```
 
 If you need to support Node 12, you can [use

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -71,6 +71,18 @@
       "moduleName": "tempy",
       "docPath": "tempy",
       "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "rimraf",
+      "docPath": "rimraf",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "mkdirp",
+      "docPath": "mkdirp",
+      "category": "preferred"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@types/node": "^20.14.9",
         "ajv": "^8.16.0",
         "prettier": "^3.2.4",
-        "rimraf": "^5.0.5",
         "ts-json-schema-generator": "^2.3.0",
         "tshy": "^1.11.0",
         "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "main": "./dist/commonjs/main.js",
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "node -e \"fs.rmSync('./dist', {force: true, recursive: true})\"",
     "prepare": "tshy && npm run build:update-manifest-paths",
     "format": "prettier --write \"./src/**/*.ts\" \"./manifests/**/*.json\"",
     "build:types": "tsc --noEmit",
@@ -36,7 +36,6 @@
     "@types/node": "^20.14.9",
     "ajv": "^8.16.0",
     "prettier": "^3.2.4",
-    "rimraf": "^5.0.5",
     "ts-json-schema-generator": "^2.3.0",
     "tshy": "^1.11.0",
     "typescript": "^5.3.3"


### PR DESCRIPTION
These packages' functionality have been integrated into Node's `fs` module, and can usually be removed.