### PR TITLE
docs: remove recommendation for shimful plugin

### DIFF
--- a/docs/modules/eslint-plugin-react.md
+++ b/docs/modules/eslint-plugin-react.md
@@ -4,13 +4,6 @@
 
 # Alternatives
 
-## `@shimful/eslint-plugin-react-lite`
-
-A small plugin with all of the essential react lint rules.
-
-[Project Page](https://github.com/shimful/eslint-plugin-react-lite)
-[NPM](https://www.npmjs.com/package/@shimful/eslint-plugin-react-lite)
-
 ## `@eslint-react/eslint-plugin`
 
 Feature rich alternative with many of the same rules.


### PR DESCRIPTION
The author is on the Discord and recommended against using it there. It had only a single release nine months ago and he's moved onto other things 