### PR TITLE
docs: add qs-esm as an alternative to qs

### DIFF
--- a/docs/modules/qs.md
+++ b/docs/modules/qs.md
@@ -19,5 +19,5 @@
 ## qs-esm
 [qs-esm](https://www.npmjs.com/package/qs-esm) is an esm-only fork of `qs` with the following core differences:
 
-- no polyfills for ancient Node versions. This reduces the amount of dependencies from 15 to 1, and the bundle size from 11kb to 4.2kb.
-- types are included, thus you do not have to install a `@types/` package anymore
+- No polyfills for legacy Node versions, making this package dependency-free and reducing bundle-size.
+- Includes TypeScript types, eliminating the need to install a separate @types/ package.

--- a/docs/modules/qs.md
+++ b/docs/modules/qs.md
@@ -15,3 +15,9 @@
 ## picoquery
 
 [picoquery](https://www.npmjs.com/package/picoquery) can be used when you need nesting and arrays.
+
+## qs-esm
+[qs-esm](https://www.npmjs.com/package/qs-esm) is an esm-only fork of `qs` with the following core differences:
+
+- no polyfills for ancient Node versions. This reduces the amount of dependencies from 15 to 1, and the bundle size from 11kb to 4.2kb.
+- types are included, thus you do not have to install a `@types/` package anymore


### PR DESCRIPTION
A lot of projects have heavy reliance on qs and their specific way of handling nested objects/arrays. It's also undeniable that their code has been battle-tested and is secure.

Thus, I forked it and got rid of all the bad parts of `qs`. While, personally, I would switch new projects to `picoquery` - the only package with nested arrays & objects support - it's
- much more effort to migrate existing projects to it
- a hard sell for larger projects, especially within companies, as it's a very recent package and is not as battle-tested as `qs`
- lacking some configuration options available in `qs`