### PR TITLE
feat: Add entry for uri-js

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -28,3 +28,4 @@ ESLint plugin.
 - [`npm-run-all`](./npm-run-all.md)
 - [`qs`](./qs.md)
 - [`tempy`](./tempy.md)
+- [`uri-js`](./uri-js.md)

--- a/docs/modules/uri-js.md
+++ b/docs/modules/uri-js.md
@@ -1,0 +1,13 @@
+# uri-js
+
+`uri-js` is unmaintained and emits [deprecation warnings](https://github.com/garycourt/uri-js/pull/95) for newer node versions. It is recommended to use a different package for RFC 3986 URI parsing.
+
+# Alternatives
+
+## `uri-js-replace`
+
+[`uri-js-replace`](https://www.npmjs.com/package/uri-js-replace) is a 0 dependency package that can replace the functionality of `uri-js`. It is designed to have the same API as `uri-js`, but with modernized code and no deprecation warnings.
+
+## `fast-uri`
+
+[`fast-uri`](https://www.npmjs.com/package/fast-uri) is a 0 dependency package that can replace the functionality of `uri-js`. It has a slightly different top-level API than `uri-js`, but it should be a drop-in replacement for most use cases, and is designed to be faster than `uri-js`.

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2051,6 +2051,12 @@
       "moduleName": "underscore",
       "docPath": "lodash-underscore",
       "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "uri-js",
+      "docPath": "uri-js",
+      "category": "preferred"
     }
   ]
 }


### PR DESCRIPTION
s/o @valadaptive - thanks for the research!

resolves https://github.com/43081j/ecosystem-cleanup/issues/60

Adds entry for `uri-js` library and recommends two alternatives, `uri-js-replace` (identical API) and `fast-uri` (different API but faster)