### PR TITLE
feat: Add is-core-module replacement

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -13,6 +13,7 @@ ESLint plugin.
 ## List of modules
 
 - [`bluebird`](./bluebird.md)
+- [`builtin-modules`](./is-builtin-module.md)
 - [`cpx`](./cpx.md)
 - [`deep-equal`](./deep-equal.md)
 - [`eslint-plugin-es`](./eslint-plugin-es.md)
@@ -21,6 +22,7 @@ ESLint plugin.
 - [`eslint-plugin-node`](./eslint-plugin-node.md)
 - [`eslint-plugin-react`](./eslint-plugin-react.md)
 - [`is-builtin-module`](./is-builtin-module.md)
+- [`is-core-module`]('./is-builtin-module.md')
 - [`jQuery`](./jquery.md)
 - [`lodash`, `underscore` and related](./lodash-underscore.md)
 - [`MaterializeCSS`](./materialize-css.md)

--- a/docs/modules/is-builtin-module.md
+++ b/docs/modules/is-builtin-module.md
@@ -1,16 +1,16 @@
-# is-builtin-module
+# is-builtin-module / builtin-modules / is-core-module
 
-`is-builtin-module` has equivalent functionality built in to node itself.
+[`is-builtin-module`](https://www.npmjs.com/package/is-builtin-module), [`builtin-modules`](https://www.npmjs.com/package/builtin-modules), and [`is-core-module`](https://www.npmjs.com/package/is-core-module) has equivalent functionality built in to Node itself for Node versions above `8.10.0`.
 
-You may not need an alternative if your runtime does not have access to the
-built-in node module.
+For cases where you are operating in non-Node runtimes (like the browser) you may still need to use these packages.
 
 # Alternatives
 
-## NodeJS (since 16.x)
+## NodeJS
 
 For determining if a module is built-in or not, you can use
-[isBuiltIn](https://nodejs.org/api/module.html#moduleisbuiltinmodulename):
+[isBuiltIn](https://nodejs.org/api/module.html#moduleisbuiltinmodulename). This requires
+Node.js `16.17.0` / `18.6.0` or higher.
 
 ```ts
 import {isBuiltin} from 'node:module';
@@ -19,12 +19,23 @@ isBuiltin('fs'); // true
 ```
 
 For a full list of built-in modules, you can use
-[builtinModules](https://nodejs.org/api/module.html#modulebuiltinmodules):
+[builtinModules](https://nodejs.org/api/module.html#modulebuiltinmodules). This can be used
+with Node.js `8.10.0` / `6.13.0` or higher.
 
 ```ts
 import {builtinModules} from 'node:module';
 
 for (const name of builtinModules) {
   console.log(name);
+}
+```
+
+If you can't use `isBuiltin`, you can replicate it's functionality with `builtinModules`:
+
+```js
+import {builtinModules} from 'node:module';
+
+function isBuiltin(name) {
+  return builtinModules.includes(name);
 }
 ```

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -62,6 +62,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "is-core-module",
+      "docPath": "is-builtin-module",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "jquery",
       "docPath": "jquery",
       "category": "preferred"


### PR DESCRIPTION
resolves https://github.com/es-tooling/module-replacements/issues/72

`is-core-module` can be replaced the same way `is-builtin-module` can.