### PR TITLE
Add more replacements: make-dir, object-keys, object-assign, readable-stream

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -29,6 +29,7 @@ ESLint plugin.
 - [`moment.js`](./momentjs.md)
 - [`npm-run-all`](./npm-run-all.md)
 - [`qs`](./qs.md)
+- [`readable-stream`](./readable-stream.md)
 - [`rimraf`](./rimraf.md)
 - [`sort-object`](./sort-object.md)
 - [`tempy`](./tempy.md)

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -24,6 +24,7 @@ ESLint plugin.
 - [`jQuery`](./jquery.md)
 - [`lodash`, `underscore` and related](./lodash-underscore.md)
 - [`MaterializeCSS`](./materialize-css.md)
+- [`make-dir`](./mkdirp.md)
 - [`mkdirp`](./mkdirp.md)
 - [`moment.js`](./momentjs.md)
 - [`npm-run-all`](./npm-run-all.md)

--- a/docs/modules/mkdirp.md
+++ b/docs/modules/mkdirp.md
@@ -1,6 +1,6 @@
-# mkdirp
+# mkdirp / make-dir
 
-`mkdirp` can often be replaced with built-in Node APIs.
+[`mkdirp`](https://www.npmjs.com/package/mkdirp) and [`make-dir`](https://www.npmjs.com/package/make-dir) can often be replaced with built-in Node APIs.
 
 # Alternatives
 

--- a/docs/modules/readable-stream.md
+++ b/docs/modules/readable-stream.md
@@ -1,0 +1,9 @@
+# readable-stream
+
+[`readable-stream`](https://www.npmjs.com/package/readable-stream) is a mirror of the NodeJS `stream` module.
+
+# Alternatives
+
+## NodeJS (since v0.9.4)
+
+If your NodeJS version is recent it is better to directly use [`stream`](https://nodejs.org/api/stream.html).

--- a/docs/modules/readable-stream.md
+++ b/docs/modules/readable-stream.md
@@ -1,9 +1,17 @@
 # readable-stream
 
-[`readable-stream`](https://www.npmjs.com/package/readable-stream) is a mirror of the NodeJS `stream` module.
+[`readable-stream`](https://www.npmjs.com/package/readable-stream) is a mirror of the NodeJS `stream` module which also works in the browser.
 
 # Alternatives
 
 ## NodeJS (since v0.9.4)
 
 If your NodeJS version is recent it is better to directly use [`stream`](https://nodejs.org/api/stream.html).
+
+## Streams API (Browsers and NodeJS 16.5.0)
+
+The [Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) is a way to have Readable, Writable and Transform streams natively in your browser.
+
+On NodeJS this API is available as a global since NodeJS 18.0.0, it needed to be imported from `stream/web` before.
+
+WebStreams are (experimentally) interoperable with NodeJS streams using [`stream.Readable.toWeb`](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options), [`stream.Writable.fromWeb`](https://nodejs.org/api/stream.html#streamwritablefromwebwritablestream-options), and [`stream.Writable.toWeb`](https://nodejs.org/api/stream.html#streamwritabletowebstreamwritable)

--- a/manifests/native.json
+++ b/manifests/native.json
@@ -442,6 +442,14 @@
     },
     {
       "type": "native",
+      "moduleName": "object-assign",
+      "nodeVersion": "4.0.0",
+      "replacement": "Object.assign",
+      "mdnPath": "Global_Objects/Object/assign",
+      "category": "native"
+    },
+    {
+      "type": "native",
       "moduleName": "object.defineproperties",
       "nodeVersion": "0.10.0",
       "replacement": "Object.defineProperties",
@@ -491,6 +499,14 @@
     {
       "type": "native",
       "moduleName": "object-keys",
+      "nodeVersion": "0.10.0",
+      "replacement": "Object.keys(obj)",
+      "mdnPath": "Global_Objects/Object/keys",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "object.keys",
       "nodeVersion": "0.10.0",
       "replacement": "Object.keys(obj)",
       "mdnPath": "Global_Objects/Object/keys",

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2063,6 +2063,12 @@
       "moduleName": "uri-js",
       "docPath": "uri-js",
       "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "readable-stream",
+      "docPath": "readable-stream",
+      "category": "preferred"
     }
   ]
 }

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2030,6 +2030,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "make-dir",
+      "docPath": "mkdirp",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "mkdirp",
       "docPath": "mkdirp",
       "category": "preferred"


### PR DESCRIPTION
* `make-dir` ( Fixes #62 ) ( Fixes #37 is already fixed )
* `object.keys` with `Object.keys` (this is identical to the `object-keys` package
* `object-assign` with `Object.assign` (this is identical to the `object.assign` package
* `readable-stream` that can be replaced by `node:stream`