### PR TITLE
fix: fix module name casing

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -842,7 +842,7 @@
     },
     {
       "type": "native",
-      "moduleName": "string.prototype.trimStart",
+      "moduleName": "string.prototype.trimstart",
       "nodeVersion": "10.0.0",
       "replacement": "String.prototype.trimStart",
       "mdnPath": "Global_Objects/String/trimStart",


### PR DESCRIPTION
Correct module name is `string.prototype.trimstart` but there was `trimStart` before.

See https://www.npmjs.com/package/string.prototype.trimstart