### PR TITLE
bugfix: fix the naming of `is-primitive`

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -62,7 +62,7 @@
     },
     {
       "type": "simple",
-      "moduleName": "is-primitve",
+      "moduleName": "is-primitive",
       "replacement": "Use v === null || (typeof v !== \"function\" && typeof v !== \"object\")",
       "category": "micro-utilities"
     },


### PR DESCRIPTION
Change `is-primitve` to `is-primitive` to match spelling of the npm package.