### PR TITLE
fix: typo `is-primitve` -> `is-primitive`

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -62,7 +62,7 @@
     },
     {
       "type": "simple",
-      "moduleName": "is-primitve",
+      "moduleName": "is-primitive",
       "replacement": "Use v === null || (typeof v !== \"function\" && typeof v !== \"object\")",
       "category": "micro-utilities"
     },


### PR DESCRIPTION
Yesterday I did a [PR for the codemod `is-primitive`](https://github.com/thepassle/module-replacements-codemods/pull/39).

After it being merged I was surprised that it still was being listed as "missing" / "left to do".

That's when I noticed the typo.
