### PR TITLE
fix: typo in package name `exponential` -> `toexponential`

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -578,7 +578,7 @@
     },
     {
       "type": "native",
-      "moduleName": "number.prototype.exponential",
+      "moduleName": "number.prototype.toexponential",
       "nodeVersion": "0.10.0",
       "replacement": "Number.prototype.toExponential",
       "mdnPath": "Global_Objects/Number/toExponential",


### PR DESCRIPTION
[Source](https://github.com/es-shims/Number.prototype.toExponential/blob/776e7261fdaf14bddee9cd822daa4bb9914ecc4b/package.json#L2)

[npmjs.com](https://www.npmjs.com/package/number.prototype.toexponential)

There's typo in his package `README.md`.
