### PR TITLE
feat: Add manifests to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,11 @@
         "types": "./dist/commonjs/main.d.ts",
         "default": "./dist/commonjs/main.js"
       }
-    }
+    },
+    "./package.json": "./package.json",
+    "./manifests/micro-utilities.json": "./manifests/micro-utilities.json",
+    "./manifests/native.json": "./manifests/native.json",
+    "./manifests/preferred.json": "./manifests/preferred.json"
   },
   "types": "./dist/commonjs/main.d.ts",
   "type": "module"


### PR DESCRIPTION
Adds the manifests to the export map so they can be accessed by tools that utilize Node's module resolution. For example, if you tried to run this:

```js
import nativeReplacements from 'module-replacements/manifests/native.json' with { type: 'json' };

console.log(nativeReplacements);
```

You'd see this:

```
node:internal/modules/esm/resolve:299
  return new ERR_PACKAGE_PATH_NOT_EXPORTED(
         ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './manifests/native.json' is not defined by "exports" in /home/ryun/Projects/deptree/node_modules/module-replacements/package.json imported from /home/ryun/Projects/deptree/index.js
```

Also adds `package.json` to the exports map too -- it's a handy thing that many other libraries offer. Never know, someone might want to access it in a script for some reason.