### PR TITLE
feat: add missing packages

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -25,6 +25,7 @@ ESLint plugin.
 - [`lodash`, `underscore` and related](./lodash-underscore.md)
 - [`MaterializeCSS`](./materialize-css.md)
 - [`make-dir`](./mkdirp.md)
+- [`md5`](./md5.md)
 - [`mkdirp`](./mkdirp.md)
 - [`moment.js`](./momentjs.md)
 - [`npm-run-all`](./npm-run-all.md)

--- a/docs/modules/md5.md
+++ b/docs/modules/md5.md
@@ -1,5 +1,7 @@
 # md5
 
+If you're using the `md5` package, you should consider using a more secure algorithm if possible, if not you can find a native Node.js alternative in the example blow.
+
 # Alternatives
 
 ## NodeJS

--- a/docs/modules/md5.md
+++ b/docs/modules/md5.md
@@ -1,0 +1,11 @@
+# md5
+
+# Alternatives
+
+## NodeJS
+
+```js
+import crypto from 'node:crypto';
+
+crypto.createHash('md5').update('message').digest('hex')`
+```

--- a/manifests/native.json
+++ b/manifests/native.json
@@ -1039,6 +1039,94 @@
       "replacement": "Array.prototype.lastIndexOf",
       "mdnPath": "Global_Objects/Array/lastIndexOf",
       "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "abort-controller",
+      "nodeVersion": "0.10.0",
+      "replacement": "AbortController",
+      "mdnPath": "Global_Objects/AbortController",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "array.prototype.findlast",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.findLast",
+      "mdnPath": "Global_Objects/Array/findLast",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "array.prototype.findlastindex",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.findLastIndex",
+      "mdnPath": "Global_Objects/Array/findLastIndex",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "array.prototype.toreversed",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.toReversed",
+      "mdnPath": "Global_Objects/Array/toReversed",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "array.prototype.tosorted",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.toSorted",
+      "mdnPath": "Global_Objects/Array/toSorted",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "array.prototype.tospliced",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.toSpliced",
+      "mdnPath": "Global_Objects/Array/toSpliced",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "array.prototype.with",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.with",
+      "mdnPath": "Global_Objects/Array/with",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "string.prototype.repeat",
+      "nodeVersion": "0.10.0",
+      "replacement": "String.prototype.repeat",
+      "mdnPath": "Global_Objects/String/repeat",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "is-builtin-module",
+      "nodeVersion": "0.10.0",
+      "replacement": "Use `isBuiltin` from 'node:module'",
+      "mdnPath": "",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "md5",
+      "nodeVersion": "0.10.0",
+      "replacement": "Use `crypto.createHash('md5').update('message').digest('hex')` from 'node:crypto'",
+      "mdnPath": "",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "setprototypeof",
+      "nodeVersion": "0.10.0",
+      "replacement": "Object.setPrototypeOf",
+      "mdnPath": "Global_Objects/Object/setPrototypeOf",
+      "category": "native"
     }
   ]
 }

--- a/manifests/native.json
+++ b/manifests/native.json
@@ -1043,7 +1043,7 @@
     {
       "type": "native",
       "moduleName": "abort-controller",
-      "nodeVersion": "0.10.0",
+      "nodeVersion": "15.0.0",
       "replacement": "AbortController",
       "mdnPath": "Global_Objects/AbortController",
       "category": "native"
@@ -1051,7 +1051,7 @@
     {
       "type": "native",
       "moduleName": "array.prototype.findlast",
-      "nodeVersion": "0.10.0",
+      "nodeVersion": "18.0.0",
       "replacement": "Array.prototype.findLast",
       "mdnPath": "Global_Objects/Array/findLast",
       "category": "native"
@@ -1059,7 +1059,7 @@
     {
       "type": "native",
       "moduleName": "array.prototype.findlastindex",
-      "nodeVersion": "0.10.0",
+      "nodeVersion": "18.0.0",
       "replacement": "Array.prototype.findLastIndex",
       "mdnPath": "Global_Objects/Array/findLastIndex",
       "category": "native"
@@ -1067,7 +1067,7 @@
     {
       "type": "native",
       "moduleName": "array.prototype.toreversed",
-      "nodeVersion": "0.10.0",
+      "nodeVersion": "20.0.0",
       "replacement": "Array.prototype.toReversed",
       "mdnPath": "Global_Objects/Array/toReversed",
       "category": "native"
@@ -1075,7 +1075,7 @@
     {
       "type": "native",
       "moduleName": "array.prototype.tosorted",
-      "nodeVersion": "0.10.0",
+      "nodeVersion": "20.0.0",
       "replacement": "Array.prototype.toSorted",
       "mdnPath": "Global_Objects/Array/toSorted",
       "category": "native"
@@ -1083,7 +1083,7 @@
     {
       "type": "native",
       "moduleName": "array.prototype.tospliced",
-      "nodeVersion": "0.10.0",
+      "nodeVersion": "20.0.0",
       "replacement": "Array.prototype.toSpliced",
       "mdnPath": "Global_Objects/Array/toSpliced",
       "category": "native"
@@ -1091,7 +1091,7 @@
     {
       "type": "native",
       "moduleName": "array.prototype.with",
-      "nodeVersion": "0.10.0",
+      "nodeVersion": "20.0.0",
       "replacement": "Array.prototype.with",
       "mdnPath": "Global_Objects/Array/with",
       "category": "native"
@@ -1099,31 +1099,15 @@
     {
       "type": "native",
       "moduleName": "string.prototype.repeat",
-      "nodeVersion": "0.10.0",
+      "nodeVersion": "4.0.0",
       "replacement": "String.prototype.repeat",
       "mdnPath": "Global_Objects/String/repeat",
       "category": "native"
     },
     {
       "type": "native",
-      "moduleName": "is-builtin-module",
-      "nodeVersion": "0.10.0",
-      "replacement": "Use `isBuiltin` from 'node:module'",
-      "mdnPath": "",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "md5",
-      "nodeVersion": "0.10.0",
-      "replacement": "Use `crypto.createHash('md5').update('message').digest('hex')` from 'node:crypto'",
-      "mdnPath": "",
-      "category": "native"
-    },
-    {
-      "type": "native",
       "moduleName": "setprototypeof",
-      "nodeVersion": "0.10.0",
+      "nodeVersion": "0.12.0",
       "replacement": "Object.setPrototypeOf",
       "mdnPath": "Global_Objects/Object/setPrototypeOf",
       "category": "native"

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2075,6 +2075,12 @@
       "moduleName": "readable-stream",
       "docPath": "readable-stream",
       "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "md5",
+      "docPath": "md5",
+      "category": "preferred"
     }
   ]
 }


### PR DESCRIPTION
I noticed there were some discrepancies between the codemods we have, and the packages that are in module-replacements. I think the codemods should always follow what's in module-replacements, so here's a PR that adds the missing packages. Once this is merged and released I'll add a script in the codemods repo that checks on PR to see if the contributed codemod is actually in module-replacements or not to avoid discrepancies in the future.