### PR TITLE
chore: add manifest validate scripts

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -8,6 +8,12 @@
     },
     {
       "type": "simple",
+      "moduleName": "clone-regexp",
+      "replacement": "Use new RegExp(regexpToCopy)",
+      "category": "micro-utilities"
+    },
+    {
+      "type": "simple",
       "moduleName": "es-get-iterator",
       "replacement": "Use v[Symbol.iterator]?.()",
       "category": "micro-utilities"
@@ -38,8 +44,20 @@
     },
     {
       "type": "simple",
+      "moduleName": "is-even",
+      "replacement": "Use (n % 2) === 0",
+      "category": "micro-utilities"
+    },
+    {
+      "type": "simple",
       "moduleName": "is-negative-zero",
       "replacement": "Use Object.is(v, -0)",
+      "category": "micro-utilities"
+    },
+    {
+      "type": "simple",
+      "moduleName": "is-npm",
+      "replacement": "Use process.env.npm_config_user_agent?.startsWith(\"npm\")",
       "category": "micro-utilities"
     },
     {
@@ -52,6 +70,12 @@
       "type": "simple",
       "moduleName": "is-number-object",
       "replacement": "Use Object.prototype.toString.call(v) === \"[object Number]\"",
+      "category": "micro-utilities"
+    },
+    {
+      "type": "simple",
+      "moduleName": "is-odd",
+      "replacement": "Use (n % 2) === 1",
       "category": "micro-utilities"
     },
     {
@@ -75,7 +99,7 @@
     {
       "type": "simple",
       "moduleName": "is-string",
-      "replacement": "Use Object.prototype.toString.call(v) === \"[object String]\"",
+      "replacement": "Use typeof str === \"string\"",
       "category": "micro-utilities"
     },
     {
@@ -86,20 +110,8 @@
     },
     {
       "type": "simple",
-      "moduleName": "is-npm",
-      "replacement": "Use process.env.npm_config_user_agent?.startsWith(\"npm\")",
-      "category": "micro-utilities"
-    },
-    {
-      "type": "simple",
-      "moduleName": "clone-regexp",
-      "replacement": "Use new RegExp(regexpToCopy)",
-      "category": "micro-utilities"
-    },
-    {
-      "type": "simple",
-      "moduleName": "split-lines",
-      "replacement": "Use str.split(/\\r?\\n/)",
+      "moduleName": "is-whitespace",
+      "replacement": "Use str.trim() === \"\" or /^\\s*$/.test(str)",
       "category": "micro-utilities"
     },
     {
@@ -110,26 +122,8 @@
     },
     {
       "type": "simple",
-      "moduleName": "is-whitespace",
-      "replacement": "Use str.trim() === \"\" or /^\\s*$/.test(str)",
-      "category": "micro-utilities"
-    },
-    {
-      "type": "simple",
-      "moduleName": "is-string",
-      "replacement": "Use typeof str === \"string\"",
-      "category": "micro-utilities"
-    },
-    {
-      "type": "simple",
-      "moduleName": "is-odd",
-      "replacement": "Use (n % 2) === 1",
-      "category": "micro-utilities"
-    },
-    {
-      "type": "simple",
-      "moduleName": "is-even",
-      "replacement": "Use (n % 2) === 0",
+      "moduleName": "split-lines",
+      "replacement": "Use str.split(/\\r?\\n/)",
       "category": "micro-utilities"
     }
   ]

--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2,34 +2,18 @@
   "moduleReplacements": [
     {
       "type": "native",
-      "moduleName": "date",
+      "moduleName": "array-buffer-byte-length",
       "nodeVersion": "0.10.0",
-      "replacement": "Date",
-      "mdnPath": "Global_Objects/Date",
+      "replacement": "ArrayBuffer.prototype.byteLength",
+      "mdnPath": "Global_Objects/ArrayBuffer/byteLength",
       "category": "native"
     },
     {
       "type": "native",
-      "moduleName": "for-each",
-      "nodeVersion": "0.12.0",
-      "replacement": "for...of (using \"Object.entries\" if dealing with objects)",
-      "mdnPath": "Statements/for...of",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "iterate-iterator",
-      "nodeVersion": "0.12.0",
-      "replacement": "for...of",
-      "mdnPath": "Statements/for...of",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "iterate-value",
-      "nodeVersion": "0.12.0",
-      "replacement": "for...of",
-      "mdnPath": "Statements/for...of",
+      "moduleName": "array-every",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.every",
+      "mdnPath": "Global_Objects/Array/every",
       "category": "native"
     },
     {
@@ -38,6 +22,30 @@
       "nodeVersion": "6.0.0",
       "replacement": "Array.prototype.includes",
       "mdnPath": "Global_Objects/Array/includes",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "array-map",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.map",
+      "mdnPath": "Global_Objects/Array/map",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "array.from",
+      "nodeVersion": "4.0.0",
+      "replacement": "Array.from",
+      "mdnPath": "Global_Objects/Array/from",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "array.of",
+      "nodeVersion": "4.0.0",
+      "replacement": "Array.of",
+      "mdnPath": "Global_Objects/Array/of",
       "category": "native"
     },
     {
@@ -130,14 +138,6 @@
     },
     {
       "type": "native",
-      "moduleName": "array.from",
-      "nodeVersion": "4.0.0",
-      "replacement": "Array.from",
-      "mdnPath": "Global_Objects/Array/from",
-      "category": "native"
-    },
-    {
-      "type": "native",
       "moduleName": "array.prototype.indexof",
       "nodeVersion": "0.10.0",
       "replacement": "Array.prototype.indexOf",
@@ -174,14 +174,6 @@
       "nodeVersion": "0.10.0",
       "replacement": "Array.prototype.map",
       "mdnPath": "Global_Objects/Array/map",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "array.of",
-      "nodeVersion": "4.0.0",
-      "replacement": "Array.of",
-      "mdnPath": "Global_Objects/Array/of",
       "category": "native"
     },
     {
@@ -250,14 +242,6 @@
     },
     {
       "type": "native",
-      "moduleName": "array-buffer-byte-length",
-      "nodeVersion": "0.10.0",
-      "replacement": "ArrayBuffer.prototype.byteLength",
-      "mdnPath": "Global_Objects/ArrayBuffer/byteLength",
-      "category": "native"
-    },
-    {
-      "type": "native",
       "moduleName": "arraybuffer.prototype.slice",
       "nodeVersion": "0.12.0",
       "replacement": "ArrayBuffer.prototype.slice",
@@ -266,18 +250,18 @@
     },
     {
       "type": "native",
-      "moduleName": "data-view-buffer",
-      "nodeVersion": "0.10.0",
-      "replacement": "DataView.prototype.buffer",
-      "mdnPath": "Global_Objects/DataView/buffer",
-      "category": "native"
-    },
-    {
-      "type": "native",
       "moduleName": "concat-map",
       "nodeVersion": "11.0.0",
       "replacement": "Array.prototype.flatMap",
       "mdnPath": "Global_Objects/Array/flatMap",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "data-view-buffer",
+      "nodeVersion": "0.10.0",
+      "replacement": "DataView.prototype.buffer",
+      "mdnPath": "Global_Objects/DataView/buffer",
       "category": "native"
     },
     {
@@ -298,6 +282,22 @@
     },
     {
       "type": "native",
+      "moduleName": "date",
+      "nodeVersion": "0.10.0",
+      "replacement": "Date",
+      "mdnPath": "Global_Objects/Date",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "defaults",
+      "nodeVersion": "4.0.0",
+      "replacement": "Object.assign, or if deep clones are needed, use structuredClone",
+      "mdnPath": "Global_Objects/Object/assign",
+      "category": "native"
+    },
+    {
+      "type": "native",
       "moduleName": "define-accessor-property",
       "nodeVersion": "0.10.0",
       "replacement": "Object.defineProperty",
@@ -314,10 +314,10 @@
     },
     {
       "type": "native",
-      "moduleName": "es-aggregate-error",
-      "nodeVersion": "15.0.0",
-      "replacement": "AggregateError",
-      "mdnPath": "Global_Objects/AggregateError",
+      "moduleName": "define-properties",
+      "nodeVersion": "0.10.0",
+      "replacement": "Object.defineProperties",
+      "mdnPath": "Global_Objects/Object/defineProperties",
       "category": "native"
     },
     {
@@ -326,6 +326,14 @@
       "nodeVersion": "16.9.0",
       "replacement": "Use errors `.cause` property and second `Error` constructors argument to define it",
       "mdnPath": "Global_Objects/Error/cause",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "es-aggregate-error",
+      "nodeVersion": "15.0.0",
+      "replacement": "AggregateError",
+      "mdnPath": "Global_Objects/AggregateError",
       "category": "native"
     },
     {
@@ -370,10 +378,34 @@
     },
     {
       "type": "native",
-      "moduleName": "functions-have-names",
+      "moduleName": "extend-shallow",
+      "nodeVersion": "4.0.0",
+      "replacement": "Object.assign, or if deep clones are needed, use structuredClone",
+      "mdnPath": "Global_Objects/Object/assign",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "filter-array",
       "nodeVersion": "0.10.0",
-      "replacement": "Always `true`",
-      "mdnPath": "Global_Objects/Function/name",
+      "replacement": "Array.prototype.filter",
+      "mdnPath": "Global_Objects/Array/filter",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "for-each",
+      "nodeVersion": "0.12.0",
+      "replacement": "for...of (using \"Object.entries\" if dealing with objects)",
+      "mdnPath": "Statements/for...of",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "function-bind",
+      "nodeVersion": "0.10.0",
+      "replacement": "Function.prototype.bind",
+      "mdnPath": "Global_Objects/Function/bind",
       "category": "native"
     },
     {
@@ -386,10 +418,10 @@
     },
     {
       "type": "native",
-      "moduleName": "global",
-      "nodeVersion": "12.0.0",
-      "replacement": "globalThis",
-      "mdnPath": "Global_Objects/globalThis",
+      "moduleName": "functions-have-names",
+      "nodeVersion": "0.10.0",
+      "replacement": "Always `true`",
+      "mdnPath": "Global_Objects/Function/name",
       "category": "native"
     },
     {
@@ -398,6 +430,14 @@
       "nodeVersion": "11.0.0",
       "replacement": "Symbol.prototype.description",
       "mdnPath": "Global_Objects/Symbol/description",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "global",
+      "nodeVersion": "12.0.0",
+      "replacement": "globalThis",
+      "mdnPath": "Global_Objects/globalThis",
       "category": "native"
     },
     {
@@ -414,6 +454,22 @@
       "nodeVersion": "0.10.0",
       "replacement": "Object.getOwnPropertyDescriptor",
       "mdnPath": "Global_Objects/Object/getOwnPropertyDescriptor",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "has",
+      "nodeVersion": "0.10.0",
+      "replacement": "Object.prototype.hasOwnProperty.call(obj, prop) (or in later versions of node, \"Object.hasOwn(obj, prop)\")",
+      "mdnPath": "Global_Objects/Object/hasOwnProperty",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "has-own-prop",
+      "nodeVersion": "0.10.0",
+      "replacement": "Object.prototype.hasOwnProperty.call(obj, prop) (or in later versions of node, \"Object.hasOwn(obj, prop)\")",
+      "mdnPath": "Global_Objects/Object/hasOwnProperty",
       "category": "native"
     },
     {
@@ -438,6 +494,62 @@
       "nodeVersion": "6.0.0",
       "replacement": "Always `true`",
       "mdnPath": "Global_Objects/Symbol/toStringTag",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "hasown",
+      "nodeVersion": "0.10.0",
+      "replacement": "Object.prototype.hasOwnProperty.call(obj, prop) (or in later versions of node, \"Object.hasOwn(obj, prop)\")",
+      "mdnPath": "Global_Objects/Object/hasOwnProperty",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "index-of",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.indexOf",
+      "mdnPath": "Global_Objects/Array/indexOf",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "is-nan",
+      "nodeVersion": "0.10.0",
+      "replacement": "Number.isNaN",
+      "mdnPath": "Global_Objects/Number/isNaN",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "iterate-iterator",
+      "nodeVersion": "0.12.0",
+      "replacement": "for...of",
+      "mdnPath": "Statements/for...of",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "iterate-value",
+      "nodeVersion": "0.12.0",
+      "replacement": "for...of",
+      "mdnPath": "Statements/for...of",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "last-index-of",
+      "nodeVersion": "0.10.0",
+      "replacement": "Array.prototype.lastIndexOf",
+      "mdnPath": "Global_Objects/Array/lastIndexOf",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "left-pad",
+      "nodeVersion": "8.0.0",
+      "replacement": "String.prototype.padStart",
+      "mdnPath": "Global_Objects/String/padStart",
       "category": "native"
     },
     {
@@ -522,6 +634,14 @@
     },
     {
       "type": "native",
+      "moduleName": "node.extend",
+      "nodeVersion": "4.0.0",
+      "replacement": "Object.assign, or if deep clones are needed, use structuredClone",
+      "mdnPath": "Global_Objects/Object/assign",
+      "category": "native"
+    },
+    {
+      "type": "native",
       "moduleName": "number.isfinite",
       "nodeVersion": "0.10.0",
       "replacement": "Number.isFinite",
@@ -578,6 +698,14 @@
     },
     {
       "type": "native",
+      "moduleName": "object-assign",
+      "nodeVersion": "4.0.0",
+      "replacement": "Object.assign",
+      "mdnPath": "Global_Objects/Object/assign",
+      "category": "native"
+    },
+    {
+      "type": "native",
       "moduleName": "object-is",
       "nodeVersion": "0.10.0",
       "replacement": "Object.is",
@@ -586,15 +714,15 @@
     },
     {
       "type": "native",
-      "moduleName": "object.assign",
-      "nodeVersion": "4.0.0",
-      "replacement": "Object.assign",
-      "mdnPath": "Global_Objects/Object/assign",
+      "moduleName": "object-keys",
+      "nodeVersion": "0.10.0",
+      "replacement": "Object.keys(obj)",
+      "mdnPath": "Global_Objects/Object/keys",
       "category": "native"
     },
     {
       "type": "native",
-      "moduleName": "object-assign",
+      "moduleName": "object.assign",
       "nodeVersion": "4.0.0",
       "replacement": "Object.assign",
       "mdnPath": "Global_Objects/Object/assign",
@@ -650,14 +778,6 @@
     },
     {
       "type": "native",
-      "moduleName": "object-keys",
-      "nodeVersion": "0.10.0",
-      "replacement": "Object.keys(obj)",
-      "mdnPath": "Global_Objects/Object/keys",
-      "category": "native"
-    },
-    {
-      "type": "native",
       "moduleName": "object.keys",
       "nodeVersion": "0.10.0",
       "replacement": "Object.keys(obj)",
@@ -670,6 +790,14 @@
       "nodeVersion": "7.0.0",
       "replacement": "Object.values",
       "mdnPath": "Global_Objects/Object/values",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "pad-left",
+      "nodeVersion": "8.0.0",
+      "replacement": "String.prototype.padStart",
+      "mdnPath": "Global_Objects/String/padStart",
       "category": "native"
     },
     {
@@ -718,6 +846,14 @@
       "nodeVersion": "6.0.0",
       "replacement": "Reflect.ownKeys",
       "mdnPath": "Global_Objects/Reflect/ownKeys",
+      "category": "native"
+    },
+    {
+      "type": "native",
+      "moduleName": "regexp.prototype.flags",
+      "nodeVersion": "6.0.0",
+      "replacement": "RegExp.prototype.flags (e.g. \"/foo/g.flags\")",
+      "mdnPath": "Global_Objects/RegExp/flags",
       "category": "native"
     },
     {
@@ -898,218 +1034,10 @@
     },
     {
       "type": "native",
-      "moduleName": "has",
-      "nodeVersion": "0.10.0",
-      "replacement": "Object.prototype.hasOwnProperty.call(obj, prop) (or in later versions of node, \"Object.hasOwn(obj, prop)\")",
-      "mdnPath": "Global_Objects/Object/hasOwnProperty",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "hasown",
-      "nodeVersion": "0.10.0",
-      "replacement": "Object.prototype.hasOwnProperty.call(obj, prop) (or in later versions of node, \"Object.hasOwn(obj, prop)\")",
-      "mdnPath": "Global_Objects/Object/hasOwnProperty",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "has-own-prop",
-      "nodeVersion": "0.10.0",
-      "replacement": "Object.prototype.hasOwnProperty.call(obj, prop) (or in later versions of node, \"Object.hasOwn(obj, prop)\")",
-      "mdnPath": "Global_Objects/Object/hasOwnProperty",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "array-map",
-      "nodeVersion": "0.10.0",
-      "replacement": "Array.prototype.map",
-      "mdnPath": "Global_Objects/Array/map",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "is-nan",
-      "nodeVersion": "0.10.0",
-      "replacement": "Number.isNaN",
-      "mdnPath": "Global_Objects/Number/isNaN",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "node.extend",
-      "nodeVersion": "4.0.0",
-      "replacement": "Object.assign, or if deep clones are needed, use structuredClone",
-      "mdnPath": "Global_Objects/Object/assign",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "extend-shallow",
-      "nodeVersion": "4.0.0",
-      "replacement": "Object.assign, or if deep clones are needed, use structuredClone",
-      "mdnPath": "Global_Objects/Object/assign",
-      "category": "native"
-    },
-    {
-      "type": "native",
       "moduleName": "xtend",
       "nodeVersion": "4.0.0",
       "replacement": "Object.assign, or if deep clones are needed, use structuredClone",
       "mdnPath": "Global_Objects/Object/assign",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "defaults",
-      "nodeVersion": "4.0.0",
-      "replacement": "Object.assign, or if deep clones are needed, use structuredClone",
-      "mdnPath": "Global_Objects/Object/assign",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "function-bind",
-      "nodeVersion": "0.10.0",
-      "replacement": "Function.prototype.bind",
-      "mdnPath": "Global_Objects/Function/bind",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "regexp.prototype.flags",
-      "nodeVersion": "6.0.0",
-      "replacement": "RegExp.prototype.flags (e.g. \"/foo/g.flags\")",
-      "mdnPath": "Global_Objects/RegExp/flags",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "define-properties",
-      "nodeVersion": "0.10.0",
-      "replacement": "Object.defineProperties",
-      "mdnPath": "Global_Objects/Object/defineProperties",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "left-pad",
-      "nodeVersion": "8.0.0",
-      "replacement": "String.prototype.padStart",
-      "mdnPath": "Global_Objects/String/padStart",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "pad-left",
-      "nodeVersion": "8.0.0",
-      "replacement": "String.prototype.padStart",
-      "mdnPath": "Global_Objects/String/padStart",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "filter-array",
-      "nodeVersion": "0.10.0",
-      "replacement": "Array.prototype.filter",
-      "mdnPath": "Global_Objects/Array/filter",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "array-every",
-      "nodeVersion": "0.10.0",
-      "replacement": "Array.prototype.every",
-      "mdnPath": "Global_Objects/Array/every",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "index-of",
-      "nodeVersion": "0.10.0",
-      "replacement": "Array.prototype.indexOf",
-      "mdnPath": "Global_Objects/Array/indexOf",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "last-index-of",
-      "nodeVersion": "0.10.0",
-      "replacement": "Array.prototype.lastIndexOf",
-      "mdnPath": "Global_Objects/Array/lastIndexOf",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "abort-controller",
-      "nodeVersion": "15.0.0",
-      "replacement": "AbortController",
-      "mdnPath": "Global_Objects/AbortController",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "array.prototype.findlast",
-      "nodeVersion": "18.0.0",
-      "replacement": "Array.prototype.findLast",
-      "mdnPath": "Global_Objects/Array/findLast",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "array.prototype.findlastindex",
-      "nodeVersion": "18.0.0",
-      "replacement": "Array.prototype.findLastIndex",
-      "mdnPath": "Global_Objects/Array/findLastIndex",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "array.prototype.toreversed",
-      "nodeVersion": "20.0.0",
-      "replacement": "Array.prototype.toReversed",
-      "mdnPath": "Global_Objects/Array/toReversed",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "array.prototype.tosorted",
-      "nodeVersion": "20.0.0",
-      "replacement": "Array.prototype.toSorted",
-      "mdnPath": "Global_Objects/Array/toSorted",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "array.prototype.tospliced",
-      "nodeVersion": "20.0.0",
-      "replacement": "Array.prototype.toSpliced",
-      "mdnPath": "Global_Objects/Array/toSpliced",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "array.prototype.with",
-      "nodeVersion": "20.0.0",
-      "replacement": "Array.prototype.with",
-      "mdnPath": "Global_Objects/Array/with",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "string.prototype.repeat",
-      "nodeVersion": "4.0.0",
-      "replacement": "String.prototype.repeat",
-      "mdnPath": "Global_Objects/String/repeat",
-      "category": "native"
-    },
-    {
-      "type": "native",
-      "moduleName": "setprototypeof",
-      "nodeVersion": "0.12.0",
-      "replacement": "Object.setPrototypeOf",
-      "mdnPath": "Global_Objects/Object/setPrototypeOf",
       "category": "native"
     }
   ]

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -8,6 +8,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "builtin-modules",
+      "docPath": "is-builtin-module",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "cpx",
       "docPath": "cpx",
       "category": "preferred"
@@ -22,12 +28,6 @@
       "type": "documented",
       "moduleName": "eslint-plugin-es",
       "docPath": "eslint-plugin-es",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "eslint-plugin-react",
-      "docPath": "eslint-plugin-react",
       "category": "preferred"
     },
     {
@@ -50,13 +50,13 @@
     },
     {
       "type": "documented",
-      "moduleName": "is-builtin-module",
-      "docPath": "is-builtin-module",
+      "moduleName": "eslint-plugin-react",
+      "docPath": "eslint-plugin-react",
       "category": "preferred"
     },
     {
       "type": "documented",
-      "moduleName": "builtin-modules",
+      "moduleName": "is-builtin-module",
       "docPath": "is-builtin-module",
       "category": "preferred"
     },
@@ -69,6 +69,36 @@
     {
       "type": "documented",
       "moduleName": "lodash",
+      "docPath": "lodash-underscore",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "lodash-amd",
+      "docPath": "lodash-underscore",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "lodash-compat",
+      "docPath": "lodash-underscore",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "lodash-es",
+      "docPath": "lodash-underscore",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "lodash-fp",
+      "docPath": "lodash-underscore",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "lodash-node",
       "docPath": "lodash-underscore",
       "category": "preferred"
     },
@@ -314,13 +344,13 @@
     },
     {
       "type": "documented",
-      "moduleName": "lodash.defaultto",
+      "moduleName": "lodash.defaultsdeep",
       "docPath": "lodash-underscore",
       "category": "preferred"
     },
     {
       "type": "documented",
-      "moduleName": "lodash.defaultsdeep",
+      "moduleName": "lodash.defaultto",
       "docPath": "lodash-underscore",
       "category": "preferred"
     },
@@ -500,13 +530,13 @@
     },
     {
       "type": "documented",
-      "moduleName": "lodash.flattendepth",
+      "moduleName": "lodash.flattendeep",
       "docPath": "lodash-underscore",
       "category": "preferred"
     },
     {
       "type": "documented",
-      "moduleName": "lodash.flattendeep",
+      "moduleName": "lodash.flattendepth",
       "docPath": "lodash-underscore",
       "category": "preferred"
     },
@@ -542,13 +572,13 @@
     },
     {
       "type": "documented",
-      "moduleName": "lodash.forin",
+      "moduleName": "lodash.foreachright",
       "docPath": "lodash-underscore",
       "category": "preferred"
     },
     {
       "type": "documented",
-      "moduleName": "lodash.foreachright",
+      "moduleName": "lodash.forin",
       "docPath": "lodash-underscore",
       "category": "preferred"
     },
@@ -1304,13 +1334,13 @@
     },
     {
       "type": "documented",
-      "moduleName": "lodash.pullby",
+      "moduleName": "lodash.pullat",
       "docPath": "lodash-underscore",
       "category": "preferred"
     },
     {
       "type": "documented",
-      "moduleName": "lodash.pullat",
+      "moduleName": "lodash.pullby",
       "docPath": "lodash-underscore",
       "category": "preferred"
     },
@@ -1958,12 +1988,6 @@
     },
     {
       "type": "documented",
-      "moduleName": "lodash.zipwith",
-      "docPath": "lodash-underscore",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
       "moduleName": "lodash.zipobject",
       "docPath": "lodash-underscore",
       "category": "preferred"
@@ -1976,56 +2000,8 @@
     },
     {
       "type": "documented",
-      "moduleName": "lodash-amd",
+      "moduleName": "lodash.zipwith",
       "docPath": "lodash-underscore",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "lodash-compat",
-      "docPath": "lodash-underscore",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "lodash-es",
-      "docPath": "lodash-underscore",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "lodash-fp",
-      "docPath": "lodash-underscore",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "lodash-node",
-      "docPath": "lodash-underscore",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "npm-run-all",
-      "docPath": "npm-run-all",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "qs",
-      "docPath": "qs",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "tempy",
-      "docPath": "tempy",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "rimraf",
-      "docPath": "rimraf",
       "category": "preferred"
     },
     {
@@ -2048,14 +2024,44 @@
     },
     {
       "type": "documented",
+      "moduleName": "npm-run-all",
+      "docPath": "npm-run-all",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "q",
       "docPath": "bluebird-q",
       "category": "preferred"
     },
     {
       "type": "documented",
+      "moduleName": "qs",
+      "docPath": "qs",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "readable-stream",
+      "docPath": "readable-stream",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "rimraf",
+      "docPath": "rimraf",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "sort-object",
       "docPath": "sort-object",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "tempy",
+      "docPath": "tempy",
       "category": "preferred"
     },
     {
@@ -2068,18 +2074,6 @@
       "type": "documented",
       "moduleName": "uri-js",
       "docPath": "uri-js",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "readable-stream",
-      "docPath": "readable-stream",
-      "category": "preferred"
-    },
-    {
-      "type": "documented",
-      "moduleName": "md5",
-      "docPath": "md5",
       "category": "preferred"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
     "format": "prettier --write \"./src/**/*.ts\" \"./manifests/**/*.json\"",
     "generate-schema": "node scripts/generate-schema.js",
     "prepare": "tshy && npm run build:update-manifest-paths",
-    "test:validate": "npm run validate-manifests && npm run validate-module-list",
-    "validate-manifests": "node scripts/validate-manifests.js",
-    "validate-module-list": "node scripts/validate-module-list.js"
+    "test:validate": "node scripts/validate-modules.js",
+    "sort-manifests": "node scripts/sort-manifests.js"
   },
   "tshy": {
     "exports": {

--- a/scripts/check-manifest-problems.js
+++ b/scripts/check-manifest-problems.js
@@ -1,0 +1,65 @@
+import {readdir, readFile} from 'node:fs/promises';
+import {fileURLToPath} from 'node:url';
+import * as path from 'node:path';
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+const manifestsDir = path.resolve(scriptDir, '../manifests');
+const seenModules = new Set();
+
+async function checkManifestForDuplicates(name, manifest) {
+  const seenInThisManifest = new Set();
+
+  for (const mod of manifest.moduleReplacements) {
+    if (seenInThisManifest.has(mod.moduleName)) {
+      throw new Error(
+        `Module ${mod.moduleName} was found multiple times in ${name}`
+      );
+    }
+    if (seenModules.has(mod.moduleName)) {
+      throw new Error(
+        `Module ${mod.moduleName} was found in multiple manifests`
+      );
+    }
+    seenInThisManifest.add(mod.moduleName);
+    seenModules.add(mod.moduleName);
+  }
+}
+
+function checkManifestIsSorted(name, manifest) {
+  const sorted = [...manifest.moduleReplacements].sort((a, b) => {
+    if (a.moduleName === b.moduleName) {
+      return 0;
+    }
+    return a.moduleName > b.moduleName ? 1 : -1;
+  });
+
+  for (let i = 0; i < sorted.length; i++) {
+    const mod = sorted[i];
+    const unsortedMod = manifest.moduleReplacements[i];
+
+    if (mod !== unsortedMod) {
+      throw new Error(`Manifest ${name} should be sorted by module name (a-z)`);
+    }
+  }
+}
+
+export async function checkManifestsForProblems() {
+  console.log('Checking for problems in manifests...');
+  const manifests = await readdir(manifestsDir);
+  seenModules.clear();
+
+  for (const manifestName of manifests) {
+    if (!manifestName.endsWith('.json')) {
+      continue;
+    }
+
+    const manifestPath = path.join(manifestsDir, manifestName);
+    const manifest = JSON.parse(
+      await readFile(manifestPath, {encoding: 'utf8'})
+    );
+
+    await checkManifestForDuplicates(manifestName, manifest);
+    checkManifestIsSorted(manifestName, manifest);
+  }
+  console.log('OK');
+}

--- a/scripts/sort-manifests.js
+++ b/scripts/sort-manifests.js
@@ -1,0 +1,24 @@
+import {readdir, readFile, writeFile} from 'node:fs/promises';
+import {fileURLToPath} from 'node:url';
+import * as path from 'node:path';
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+const manifestsDir = path.resolve(scriptDir, '../manifests');
+const manifests = await readdir(manifestsDir);
+
+for (const manifestName of manifests) {
+  if (!manifestName.endsWith('.json')) {
+    continue;
+  }
+
+  const manifestPath = path.join(manifestsDir, manifestName);
+  const manifest = JSON.parse(await readFile(manifestPath, {encoding: 'utf8'}));
+  manifest.moduleReplacements.sort((a, b) => {
+    if (a.moduleName === b.moduleName) {
+      return 0;
+    }
+    return a.moduleName > b.moduleName ? 1 : -1;
+  });
+
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+}

--- a/scripts/update-manifests-dist-path.js
+++ b/scripts/update-manifests-dist-path.js
@@ -4,13 +4,13 @@ import * as path from 'node:path';
 
 const scriptDir = fileURLToPath(new URL('.', import.meta.url));
 const distPath = path.resolve(scriptDir, '../dist');
-const flavours = ['esm', 'commonjs']
+const flavours = ['esm', 'commonjs'];
 
 for (const flavour of flavours) {
   const flavourPath = `${distPath}/${flavour}/manifests-dir.js`;
   const contents = await readFile(flavourPath, 'utf8');
-  await writeFile(flavourPath, contents.replaceAll(
-    '../manifests',
-    '../../manifests'
-  ));
+  await writeFile(
+    flavourPath,
+    contents.replaceAll('../manifests', '../../manifests')
+  );
 }

--- a/scripts/validate-manifests.js
+++ b/scripts/validate-manifests.js
@@ -7,20 +7,27 @@ const validator = new ajv();
 const scriptDir = fileURLToPath(new URL('.', import.meta.url));
 const manifestsDir = path.resolve(scriptDir, '../manifests');
 const schemaPath = path.resolve(scriptDir, '../manifest-schema.json');
-const manifests = await readdir(manifestsDir);
-const schema = JSON.parse(await readFile(schemaPath, {encoding: 'utf8'}));
-const validate = validator.compile(schema);
 
-for (const manifestName of manifests) {
-  if (!manifestName.endsWith('.json')) {
-    continue;
-  }
+export async function validateManifests() {
+  console.log('Validating manifests against JSON schema...');
+  const manifests = await readdir(manifestsDir);
+  const schema = JSON.parse(await readFile(schemaPath, {encoding: 'utf8'}));
+  const validate = validator.compile(schema);
 
-  const manifestPath = path.join(manifestsDir, manifestName);
-  const manifest = JSON.parse(await readFile(manifestPath, {encoding: 'utf8'}));
-  const isValid = validate(manifest);
-  if (!isValid) {
-    console.log(validate.errors);
-    throw new Error(`Validation for ${manifestPath} failed!`);
+  for (const manifestName of manifests) {
+    if (!manifestName.endsWith('.json')) {
+      continue;
+    }
+
+    const manifestPath = path.join(manifestsDir, manifestName);
+    const manifest = JSON.parse(
+      await readFile(manifestPath, {encoding: 'utf8'})
+    );
+    const isValid = validate(manifest);
+    if (!isValid) {
+      console.log(validate.errors);
+      throw new Error(`Validation for ${manifestPath} failed!`);
+    }
   }
+  console.log('OK');
 }

--- a/scripts/validate-module-list.js
+++ b/scripts/validate-module-list.js
@@ -3,27 +3,31 @@ import * as path from 'node:path';
 import {readFile, readdir} from 'node:fs/promises';
 
 const scriptDir = fileURLToPath(new URL('.', import.meta.url));
-
 const moduleListDir = path.resolve(scriptDir, '..', 'docs', 'modules');
 const moduleListReadmePath = path.resolve(moduleListDir, 'README.md');
 
-const moduleListReadme = await readFile(moduleListReadmePath, {
-  encoding: 'utf8'
-});
-const listOfDocumentedModules = moduleListReadme.split('## List of modules')[1];
+export async function validateModuleList() {
+  console.log('Validating README contains all documented modules...');
+  const moduleListReadme = await readFile(moduleListReadmePath, {
+    encoding: 'utf8'
+  });
+  const listOfDocumentedModules =
+    moduleListReadme.split('## List of modules')[1];
 
-const files = await readdir(moduleListDir);
-for (const file of files) {
-  if (!file.endsWith('.md') || file === 'README.md') {
-    continue;
-  }
+  const files = await readdir(moduleListDir);
+  for (const file of files) {
+    if (!file.endsWith('.md') || file === 'README.md') {
+      continue;
+    }
 
-  if (!listOfDocumentedModules.includes(file)) {
-    throw new Error(
-      `Module ${file} is not listed in the README.md but was found in modules documentation.
-      Please add
-        - [\`${file.slice(0, -3)}\`](./${file})
-      to ./docs/modules/README.md`
-    );
+    if (!listOfDocumentedModules.includes(file)) {
+      throw new Error(
+        `Module ${file} is not listed in the README.md but was found in modules documentation.
+        Please add
+          - [\`${file.slice(0, -3)}\`](./${file})
+        to ./docs/modules/README.md`
+      );
+    }
   }
+  console.log('OK');
 }

--- a/scripts/validate-modules.js
+++ b/scripts/validate-modules.js
@@ -1,0 +1,7 @@
+import {validateModuleList} from './validate-module-list.js';
+import {validateManifests} from './validate-manifests.js';
+import {checkManifestsForProblems} from './check-manifest-problems.js';
+
+await validateManifests();
+await validateModuleList();
+await checkManifestsForProblems();


### PR DESCRIPTION
Adds some scripts to check the following:

- Module lists are sorted a-z
- No manifest contains duplicate modules

Also adds a script for sorting the module lists and writing the files back to disk.