### PR TITLE
feat: add ora alternatives

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -33,6 +33,7 @@ ESLint plugin.
 - [`mkdirp`](./mkdirp.md)
 - [`moment.js`](./momentjs.md)
 - [`npm-run-all`](./npm-run-all.md)
+- [`ora`](./ora.md)
 - [`qs`](./qs.md)
 - [`readable-stream`](./readable-stream.md)
 - [`rimraf`](./rimraf.md)

--- a/docs/modules/ora.md
+++ b/docs/modules/ora.md
@@ -1,0 +1,21 @@
+# ora
+
+If you don't need to customize CLI spinners, `ora` can be replaced with leaner alternatives.
+
+# Alternatives
+
+## nanospinner
+
+`nanospinner` is a simple and tiny terminal spinner library for NodeJS
+
+[Project Page](https://github.com/usmanyunusov/nanospinner)
+
+[npm](https://www.npmjs.com/package/nanospinner)
+
+## tiny-spinner
+
+`tiny-spinner` is another tiny terminal spinner library for NodeJS
+
+[Project Page](https://github.com/fabiospampinato/tiny-spinner)
+
+[npm](https://www.npmjs.com/package/tiny-spinner)

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2066,6 +2066,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "ora",
+      "docPath": "ora",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "q",
       "docPath": "bluebird-q",
       "category": "preferred"


### PR DESCRIPTION
## Overview

Closes #144 

This pull request adds `ora` as a list of dependencies that can be replaced with smaller alternatives. The alternatives considered are:

1. [`nanospinner`](https://github.com/usmanyunusov/nanospinner)
2. [`tiny-spinner`](https://github.com/fabiospampinato/tiny-spinner)