### PR TITLE
docs: register ezspawn and @jsdevtools/ez-spawn as process exec libraries

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -12,6 +12,7 @@ ESLint plugin.
 
 ## List of modules
 
+- [`@jsdevtools/ez-spawn`](./process-exec.md)
 - [`bluebird` / `q`](./bluebird-q.md)
 - [`cpx`](./cpx.md)
 - [`deep-equal`](./deep-equal.md)
@@ -21,6 +22,7 @@ ESLint plugin.
 - [`eslint-plugin-node`](./eslint-plugin-node.md)
 - [`eslint-plugin-react`](./eslint-plugin-react.md)
 - [`execa`](./process-exec.md)
+- [`ezspawn`](./process-exec.md)
 - [`fast-glob`](./glob.md)
 - [`glob`](./glob.md)
 - [`globby`](./glob.md)

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2,6 +2,12 @@
   "moduleReplacements": [
     {
       "type": "documented",
+      "moduleName": "@jsdevtools/ez-spawn",
+      "docPath": "process-exec",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "bluebird",
       "docPath": "bluebird-q",
       "category": "preferred"
@@ -57,6 +63,12 @@
     {
       "type": "documented",
       "moduleName": "execa",
+      "docPath": "process-exec",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "ezspawn",
       "docPath": "process-exec",
       "category": "preferred"
     },


### PR DESCRIPTION
## Overview

Closes #141 

This pull request registers `ezspawn` and `@jsdevtools/ez-spawn` as replaceable process execution libraries.