### PR TITLE
docs: Add faker, xmldom and eslint-plugin-vitest

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -21,6 +21,7 @@ ESLint plugin.
 - [`eslint-plugin-import`](./eslint-plugin-import.md)
 - [`eslint-plugin-node`](./eslint-plugin-node.md)
 - [`eslint-plugin-react`](./eslint-plugin-react.md)
+- [`eslint-plugin-vitest`](./eslint-plugin-vitest.md)
 - [`execa`](./process-exec.md)
 - [`ezspawn`](./process-exec.md)
 - [`fast-glob`](./glob.md)

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -24,6 +24,7 @@ ESLint plugin.
 - [`eslint-plugin-vitest`](./eslint-plugin-vitest.md)
 - [`execa`](./process-exec.md)
 - [`ezspawn`](./process-exec.md)
+- [`faker`](./faker.md)
 - [`fast-glob`](./glob.md)
 - [`glob`](./glob.md)
 - [`globby`](./glob.md)

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -49,3 +49,4 @@ ESLint plugin.
 - [`tempy`](./tempy.md)
 - [`traverse`](./traverse.md)
 - [`uri-js`](./uri-js.md)
+- [`xmldom`](./xmldom.md)

--- a/docs/modules/eslint-plugin-vitest.md
+++ b/docs/modules/eslint-plugin-vitest.md
@@ -1,0 +1,12 @@
+# eslint-plugin-vitest
+
+`eslint-plugin-vitest` is no longer maintained because the [original maintainer has lost access to their old npm account](https://github.com/vitest-dev/eslint-plugin-vitest/issues/537).
+
+# Alternatives
+
+## `@vitest/eslint-plugin`
+
+The same project as `eslint-plugin-vitest` but re-published under a different name.
+
+[Project Page](https://github.com/vitest-dev/eslint-plugin-vitest)
+[npm](https://www.npmjs.com/package/@vitest/eslint-plugin)

--- a/docs/modules/faker.md
+++ b/docs/modules/faker.md
@@ -1,0 +1,12 @@
+# faker
+
+`faker` is [no longer maintained](https://fakerjs.dev/about/announcements/2022-01-14.html#i-heard-something-happened-what-s-the-tldr). Actively maintained alternatives exist.
+
+# Alternatives
+
+## `@faker-js/faker`
+
+Direct fork which is actively maintained. It has new features, bugfixes and updated dependencies.
+
+[Project Page](https://github.com/faker-js/faker)
+[npm](https://www.npmjs.com/package/@faker-js/faker)

--- a/docs/modules/xmldom.md
+++ b/docs/modules/xmldom.md
@@ -1,0 +1,12 @@
+# xmldom
+
+`xmldom` is no longer maintained. Actively maintained alternatives exist.
+
+# Alternatives
+
+## `@xmldom/xmldom`
+
+Direct fork which is actively maintained. It has new features, bugfixes and updated dependencies.
+
+[Project Page](https://github.com/xmldom/xmldom)
+[npm](https://www.npmjs.com/package/@xmldom/xmldom)

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2171,6 +2171,12 @@
       "moduleName": "uri-js",
       "docPath": "uri-js",
       "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "xmldom",
+      "docPath": "xmldom",
+      "category": "preferred"
     }
   ]
 }

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -62,6 +62,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "eslint-plugin-vitest",
+      "docPath": "eslint-plugin-vitest",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "execa",
       "docPath": "process-exec",
       "category": "preferred"

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -80,6 +80,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "faker",
+      "docPath": "faker",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "fast-glob",
       "docPath": "glob",
       "category": "preferred"


### PR DESCRIPTION
# Overview

Closes https://github.com/es-tooling/module-replacements/issues/167

This pull request adds alternative replacements for [faker](https://www.npmjs.com/package/faker), [xmldom](https://www.npmjs.com/package/xmldom) and [eslint-plugin-vitest](https://www.npmjs.com/package/eslint-plugin-vitest).