### PR TITLE
docs: add picospinner to ora docs

### DIFF
--- a/docs/modules/ora.md
+++ b/docs/modules/ora.md
@@ -12,6 +12,14 @@ If you don't need to customize CLI spinners, `ora` can be replaced with leaner a
 
 [npm](https://www.npmjs.com/package/nanospinner)
 
+## picospinner
+
+`picospinner` is another tiny terminal spinner library for NodeJS, maintained by the [tinylibs](https://github.com/tinylibs) folks.
+
+[Project Page](https://github.com/tinylibs/picospinner)
+
+[npm](https://www.npmjs.com/package/picospinner)
+
 ## tiny-spinner
 
 `tiny-spinner` is another tiny terminal spinner library for NodeJS


### PR DESCRIPTION
Adds `picospinner` to the list of alternatives for `ora`.