### PR TITLE
Mention nodejs `--env-file-if-exists` in dotenv alternatives

### DIFF
--- a/docs/modules/dotenv.md
+++ b/docs/modules/dotenv.md
@@ -11,9 +11,11 @@ Modern and secure alternative by the same author. It supports encryption, and mu
 [Project Page](https://github.com/dotenvx/dotenvx)
 [npm](https://www.npmjs.com/package/@dotenvx/dotenvx)
 
-### Node.js --env-file
+### Node.js --env-file / --env-file-if-exists
 
-Built into Node.js since v20.6.0. Zero dependencies, good for simple use cases.
+Built into Node.js since v20.6.0 (v22.9.0 for `--env-file-if-exists`). Zero dependencies, good for simple use cases.
+
+`--env-file` will raise an error if the env-file does not exist. For those cases, where the env-file might or might not exist, use `--env-file-if-exists`.
 
 ```bash
 node --env-file=.env index.js
@@ -21,4 +23,4 @@ node --env-file=.env index.js
 
 Also supported by [tsx](https://www.npmjs.com/package/tsx), [Bun](https://bun.sh/docs/runtime/env#manually-specifying-env-files), and [Deno](https://docs.deno.com/runtime/reference/env_variables/#.env-file).
 
-[Node docs](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--env-fileconfig)
+Node docs: [`--env-file`](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--env-fileconfig) / [`--env-file-if-exists`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--env-file-if-existsconfig)


### PR DESCRIPTION
This relatively new nodejs flag is even closer in behavior to `import 'dotenv/config'`, since node will not refuse to start if the env-file does not exist.

Ref #152