### PR TITLE
docs: add chalk to preferred manifest

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -17,6 +17,7 @@ ESLint plugin.
 - [`body-parser`](./body-parser.md)
 - [`buf-compare`](./buf-compare.md)
 - [`buffer-equal` / `buffer-equals`](./buffer-equal.md)
+- [`chalk`](./chalk.md)
 - [`cpx`](./cpx.md)
 - [`deep-equal`](./deep-equal.md)
 - [`dotenv`](./dotenv.md)

--- a/docs/modules/chalk.md
+++ b/docs/modules/chalk.md
@@ -1,0 +1,35 @@
+# chalk
+
+`chalk` and similar libraries have various alternatives which are lighter and faster.
+
+# Alternatives
+
+## picocolors
+
+A widely used alternative which is much lighter and faster.
+
+[Project Page](https://github.com/alexeyraspopov/picocolors)
+
+[npm](https://npmjs.com/package/picocolors)
+
+## ansis
+
+A lighter alternative which also supports 256 color creation.
+
+[Project Page](https://github.com/webdiscus/ansis)
+
+[npm](https://npmjs.com/package/ansis)
+
+## styleText (Node 20.x and above)
+
+Node itself has a `styleText` function in the built-in `util` library.
+
+You can use it like so:
+
+```ts
+import { styleText } from 'node:util';
+
+styleText('green', 'Success!')
+```
+
+[Project Page](https://nodejs.org/api/util.html#utilstyletextformat-text-options)

--- a/docs/modules/chalk.md
+++ b/docs/modules/chalk.md
@@ -1,6 +1,6 @@
 # chalk
 
-`chalk` and similar libraries have various alternatives which are lighter and faster.
+`chalk`, `cli-color`, and similar libraries have various alternatives which are lighter and faster.
 
 # Alternatives
 

--- a/docs/modules/chalk.md
+++ b/docs/modules/chalk.md
@@ -26,7 +26,7 @@ Node itself has a `styleText` function in the built-in `util` library.
 
 You can use it like so:
 
-```ts
+```js
 import { styleText } from 'node:util';
 
 styleText('green', 'Success!')

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -44,6 +44,18 @@
     },
     {
       "type": "documented",
+      "moduleName": "chalk",
+      "docPath": "chalk",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
+      "moduleName": "cli-color",
+      "docPath": "chalk",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "cpx",
       "docPath": "cpx",
       "category": "preferred"


### PR DESCRIPTION
Adds `chalk` and `cli-color` to the preferred manifest and documents alternatives.

Closes #149