### PR TITLE
Add js-yaml

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -38,6 +38,7 @@ ESLint plugin.
 - [`invariant`](./invariant.md)
 - [`is-builtin-module`](./is-builtin-module.md)
 - [`jQuery`](./jquery.md)
+- [`js-yaml`](./js-yaml.md)
 - [`lint-staged`](./lint-staged.md)
 - [`lodash`, `underscore` and related](./lodash-underscore.md)
 - [`MaterializeCSS`](./materialize-css.md)

--- a/docs/modules/js-yaml.md
+++ b/docs/modules/js-yaml.md
@@ -1,0 +1,13 @@
+# `js-yaml`
+
+`js-yaml` appears to be no longer maintained. It also parses some YAML incorrectly.
+
+## Alternatives
+
+### `yaml`
+
+`yaml` is a better JavaScript YAML parser. It’s maintained, follows the YAML spec more closely, and has support for more features, such a modifying YAML content.
+
+[Project Page](https://eemeli.org/yaml/)
+
+[npm](https://www.npmjs.com/package/yaml)

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -182,6 +182,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "js-yaml",
+      "docPath": "js-yaml",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "lint-staged",
       "docPath": "lint-staged",
       "category": "preferred"


### PR DESCRIPTION
This recommends `yaml` over `js-yaml`.

Closes #197