### PR TITLE
docs: added `axios`

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -13,6 +13,7 @@ ESLint plugin.
 ## List of modules
 
 - [`@jsdevtools/ez-spawn`](./process-exec.md)
+- [`axios`](./axios.md)
 - [`bluebird` / `q`](./bluebird-q.md)
 - [`body-parser`](./body-parser.md)
 - [`buf-compare`](./buf-compare.md)

--- a/docs/modules/axios.md
+++ b/docs/modules/axios.md
@@ -1,0 +1,40 @@
+# axios
+
+`axios` is a popular HTTP client library, but modern JavaScript and Node.js provide native alternatives that can often replace it for many use cases.
+
+# Alternatives
+
+## Native `fetch` API
+
+The native `fetch` API is now available in Node.js (since v18.x) and all modern browsers. For most HTTP requests, it can replace axios without additional dependencies.
+
+```js
+// GET request
+const response = await fetch('https://api.example.com/data');
+const data = await response.json();
+
+// POST request with JSON
+const response = await fetch('https://api.example.com/data', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({ key: 'value' })
+});
+```
+
+[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+
+## ky
+
+`ky` is a tiny and elegant HTTP client based on the Fetch API. It provides a more convenient API than raw fetch while being much smaller than axios.
+
+[Project Page](https://github.com/sindresorhus/ky)
+[npm](https://www.npmjs.com/package/ky)
+
+## ofetch
+
+`ofetch` is a better fetch API with automatic response parsing, request/response interceptors, and retry functionality.
+
+[Project Page](https://github.com/unjs/ofetch)
+[npm](https://www.npmjs.com/package/ofetch)

--- a/docs/modules/axios.md
+++ b/docs/modules/axios.md
@@ -27,7 +27,7 @@ const response = await fetch('https://api.example.com/data', {
 
 ## ky
 
-`ky` is a tiny and elegant HTTP client based on the Fetch API. It provides a more convenient API than raw fetch while being much smaller than axios.
+`ky` is a tiny and elegant HTTP client based on the Fetch API. It provides a more convenient API than raw fetch while being much smaller than axios. Also, includes `hooks` (interceptors) for request/response modification.
 
 [Project Page](https://github.com/sindresorhus/ky)
 [npm](https://www.npmjs.com/package/ky)

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -8,6 +8,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "axios",
+      "docPath": "axios",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "bluebird",
       "docPath": "bluebird-q",
       "category": "preferred"


### PR DESCRIPTION
Hi there 👋 

This PR adds documentation for `axios` alternatives to help developers reduce dependencies by using native solutions or lightweight libraries.

What's included:
- Native fetch API: The primary recommendation, now available in Node.js 18+ and all modern browsers
- ky: Tiny HTTP client based on fetch with a convenient API
- ofetch: Enhanced fetch with automatic parsing and interceptors

Key benefits:
- Reduce bundle size by eliminating axios dependency (axios is ~13KB minified + gzipped)
- Use native browser/Node.js APIs when possible