### PR TITLE
feat: add replacement for is-negative in micro-utilities

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -50,6 +50,12 @@
     },
     {
       "type": "simple",
+      "moduleName": "is-negative",
+      "replacement": "Use (n) => n < 0",
+      "category": "micro-utilities"
+    },
+    {
+      "type": "simple",
       "moduleName": "is-negative-zero",
       "replacement": "Use Object.is(v, -0)",
       "category": "micro-utilities"


### PR DESCRIPTION
**Problem Statement:**
Add a replacement mapping for `is-negative` to remove an unnecessary dependency.
**Closes:** #211
Ran npm run build:update-manifest-paths — completed successfully
**Solution:**
```json
{
  "type": "simple",
  "moduleName": "is-negative",
  "replacement": "Use (n) => n < 0",
  "category": "micro-utilities"
}