### PR TITLE
docs: add dot-prop to preferred list

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -23,6 +23,7 @@ ESLint plugin.
 - [`deep-equal`](./deep-equal.md)
 - [`depcheck`](./depcheck.md)
 - [`dotenv`](./dotenv.md)
+- [`dot-prop`](./dot-prop.md)
 - [`emoji-regex`](./emoji-regex.md)
 - [`eslint-plugin-es`](./eslint-plugin-es.md)
 - [`eslint-plugin-eslint-comments`](./eslint-plugin-eslint-comments.md)

--- a/docs/modules/dot-prop.md
+++ b/docs/modules/dot-prop.md
@@ -1,0 +1,21 @@
+# dot-prop
+
+Much smaller and faster alternatives exist for `dot-prop`.
+
+# Alternatives
+
+## dlv
+
+`dlv` can be used for getting a dot-notation deep property from an object.
+
+[Project Page](https://github.com/developit/dlv)
+
+[npm](https://www.npmjs.com/package/dlv)
+
+## dset
+
+`dset` can be used for setting a dot-notation deep property in an object.
+
+[Project Page](https://github.com/lukeed/dset)
+
+[npm](https://www.npmjs.com/package/dset)

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -80,6 +80,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "dot-prop",
+      "docPath": "dot-prop",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "dotenv",
       "docPath": "dotenv",
       "category": "preferred"


### PR DESCRIPTION
Adds `dot-prop` since it unnecessarily pulls in ~400KB of utils.
