### PR TITLE
feat: add string-width to preferred manifest

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -59,6 +59,7 @@ ESLint plugin.
 - [`rimraf`](./rimraf.md)
 - [`shortid`](./shortid.md)
 - [`sort-object`](./sort-object.md)
+- [`string-width`](./string-width.md)
 - [`strip-ansi`](./strip-ansi.md)
 - [`tempy`](./tempy.md)
 - [`traverse`](./traverse.md)

--- a/docs/modules/string-width.md
+++ b/docs/modules/string-width.md
@@ -1,0 +1,12 @@
+# string-width
+
+`string-width` can be replaced with more modern alternatives which also come with performance and size improvements.
+
+# Alternatives
+
+## fast-string-width
+
+Originally a fork of `string-width`, but much faster and smaller.
+
+[Project Page](https://github.com/fabiospampinato/fast-string-width)
+[npm](https://www.npmjs.com/package/fast-string-width)

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2294,6 +2294,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "string-width",
+      "docPath": "string-width",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "strip-ansi",
       "docPath": "strip-ansi",
       "category": "preferred"


### PR DESCRIPTION
Adds `string-width` since the `fast-string-width` fork is much faster.
