### PR TITLE
docs: add Unicode RegExp alternative to emoji-regex

### DIFF
--- a/docs/modules/emoji-regex.md
+++ b/docs/modules/emoji-regex.md
@@ -11,3 +11,19 @@ There are alternative packages to `emoji-regex` whilst being smaller in package 
 [Project Page](https://github.com/slevithan/emoji-regex-xs)
 
 [npm](https://npmjs.com/package/emoji-regex-xs)
+
+## Unicode RegExp (native)
+
+If your target runtime supports ES2024 Unicode property sets, you can use the native [`\p{RGI_Emoji}`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) property in a regular expression. This relies on the engine's built‑in Unicode handling.
+
+```ts
+import emojiRegex from 'emoji-regex'
+
+const regex = emojiRegex()
+const regex = /\p{RGI_Emoji}/gv
+
+for (const match of text.matchAll(regex)) {
+  const emoji = match[0]
+  console.log(`Matched sequence ${emoji} — code points: ${[...emoji].length}`)
+}
+```


### PR DESCRIPTION
suddenly remembered I forgot about this

we added it to the e18e replacements docs here:

https://github.com/e18e/e18e/pull/78#discussion_r2297263841
