### PR TITLE
feat: add `core-util-is` to the preferred manifest

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -19,6 +19,7 @@ ESLint plugin.
 - [`buf-compare`](./buf-compare.md)
 - [`buffer-equal` / `buffer-equals`](./buffer-equal.md)
 - [`chalk`](./chalk.md)
+- [`core-util-is`](./core-util-is.md)
 - [`cpx`](./cpx.md)
 - [`deep-equal`](./deep-equal.md)
 - [`depcheck`](./depcheck.md)

--- a/docs/modules/core-util-is.md
+++ b/docs/modules/core-util-is.md
@@ -8,4 +8,4 @@ Legacy Node v0.12-era helpers for util.is* type checks. Unnecessary on modern No
 
 Official, cross‑realm type checks for built-in objects to fully replace core-util-is.
 
-[Project Page](https://nodejs.org/api/util.html#utiltypes)
+[Documentation Page](https://nodejs.org/api/util.html#utiltypes)

--- a/docs/modules/core-util-is.md
+++ b/docs/modules/core-util-is.md
@@ -1,0 +1,11 @@
+# core-util-is
+
+Legacy Node v0.12-era helpers for util.is* type checks. Unnecessary on modern Node.js.
+
+# Alternatives
+
+## node:util types
+
+Official, cross‑realm type checks for built-in objects to fully replace core-util-is.
+
+[Project Page](https://nodejs.org/api/util.html#utiltypes)

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -62,6 +62,12 @@
     },
     {
       "type": "documented",
+      "moduleName": "core-util-is",
+      "docPath": "core-util-is",
+      "category": "preferred"
+    },
+    {
+      "type": "documented",
       "moduleName": "cpx",
       "docPath": "cpx",
       "category": "preferred"


### PR DESCRIPTION
closes #172 