### PR TITLE
docs: add es-toolkit as lodash alternative

### DIFF
--- a/docs/modules/lodash-underscore.md
+++ b/docs/modules/lodash-underscore.md
@@ -13,3 +13,7 @@ The same situation with custom `lodash` builds like `lodash-es`.
 Here you could read how to replace Lodash or Underscore in your project.
 
 [Website](https://you-dont-need.github.io/You-Dont-Need-Lodash-Underscore)
+
+## es-toolkit
+
+[es-toolkit](https://es-toolkit.dev/) is a utility library similar to lodash that is designed to replace lodash by offering a seamless compat layer. It supports tree shaking out of the box and offers better performances for modern JavaScript runtimes.


### PR DESCRIPTION
## Overview

Closes #217 

This pull request adds [es-toolkit](https://es-toolkit.dev/) as possible alternative to lodash.