### PR TITLE
feat: add `is-stream` to micro utilities

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -164,6 +164,12 @@
     },
     {
       "type": "simple",
+      "moduleName": "is-stream",
+      "replacement": "Use `isReadable(stream) || isWritable(stream)` from `node:stream`.",
+      "category": "micro-utilities"
+    },
+    {
+      "type": "simple",
       "moduleName": "is-string",
       "replacement": "Use typeof str === \"string\"",
       "category": "micro-utilities"


### PR DESCRIPTION
You can use the built-in `isWritable` and `isReadable` to determine if
an object is a stream.
