### PR TITLE
Sync rm functions are not using promises

### DIFF
--- a/docs/modules/rimraf.md
+++ b/docs/modules/rimraf.md
@@ -24,8 +24,8 @@ await rm('./dist', { recursive: true, force: true }) // [!code ++]
 import rimraf from 'rimraf' // [!code --]
 import * as fs from 'node:fs' // [!code ++]
 
-await rimraf.sync('./dist') // [!code --]
-await fs.rmSync('./dist', { recursive: true, force: true }) // [!code ++]
+rimraf.sync('./dist') // [!code --]
+fs.rmSync('./dist', { recursive: true, force: true }) // [!code ++]
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
… right? 😅 

at least https://nodejs.org/api/fs.html#fsrmsyncpath-options

> Returns `undefined`.

https://github.com/isaacs/rimraf?tab=readme-ov-file#api

> All removal functions return a boolean indicating that all entries were successfully removed.

(except where promise, I suppose)