### PR TITLE
docs: standardize repository links to use github

### DIFF
--- a/docs/modules/deep-equal.md
+++ b/docs/modules/deep-equal.md
@@ -23,7 +23,7 @@ isDeepStrictEqual(a, b) // true [!code ++]
 
 ## `dequal`
 
-[`dequal`](https://www.npmjs.com/package/dequal) has the same simple API as `deep-equal`.
+[`dequal`](https://github.com/lukeed/dequal) has the same simple API as `deep-equal`.
 
 Example:
 

--- a/docs/modules/detect-package-manager.md
+++ b/docs/modules/detect-package-manager.md
@@ -6,7 +6,7 @@ description: Lightweight alternative to detect-package-manager for detecting the
 
 ## `package-manager-detector`
 
-[`package-manager-detector`](https://www.npmjs.com/package/package-manager-detector) is a lightweight alternative for detecting the package manager being used in a project.
+[`package-manager-detector`](https://github.com/antfu-collective/package-manager-detector) is a lightweight alternative for detecting the package manager being used in a project.
 
 ### Key differences
 

--- a/docs/modules/dotenv.md
+++ b/docs/modules/dotenv.md
@@ -16,7 +16,7 @@ node --env-file=.env index.js
 
 Also supported by:
 
-- [tsx](https://www.npmjs.com/package/tsx)
+- [tsx](https://github.com/privatenumber/tsx)
 - [Bun](https://bun.sh/docs/runtime/env#manually-specifying-env-files)
 - [Deno](https://docs.deno.com/runtime/reference/env_variables/#.env-file)
 

--- a/docs/modules/lint-staged.md
+++ b/docs/modules/lint-staged.md
@@ -6,7 +6,7 @@ description: Modern alternatives to lint-staged for running commands on staged G
 
 ## `nano-staged`
 
-[`nano-staged`](https://www.npmjs.com/package/nano-staged) is a tiny pre-commit runner for staged (and more) files; much smaller and faster than `lint-staged`, with a simple config.
+[`nano-staged`](https://github.com/usmanyunusov/nano-staged) is a tiny pre-commit runner for staged (and more) files; much smaller and faster than `lint-staged`, with a simple config.
 
 package.json config:
 

--- a/docs/modules/qs.md
+++ b/docs/modules/qs.md
@@ -23,7 +23,7 @@ const a = sp.getAll('a') // [!code ++]
 
 ## `fast-querystring`
 
-[`fast-querystring`](https://www.npmjs.com/package/fast-querystring) is tiny and very fast. It handles flat key/value pairs and repeated keys as arrays; it does not support nested objects. Use it when you need arrays but not nesting.
+[`fast-querystring`](https://github.com/anonrig/fast-querystring) is tiny and very fast. It handles flat key/value pairs and repeated keys as arrays; it does not support nested objects. Use it when you need arrays but not nesting.
 
 Example:
 
@@ -40,7 +40,7 @@ const str = fqs.stringify({ tag: ['a', 'b'], q: 'x y' }) // [!code ++]
 
 ## `picoquery`
 
-[`picoquery`](https://www.npmjs.com/package/picoquery) supports nesting and arrays with a fast single‑pass parser and configurable syntax. v2.x and above are ESM‑only; v1.x is CommonJS and will be maintained with non‑breaking changes. `nestingSyntax: 'js'` offers the highest compatibility with `qs`, though you can pick other syntaxes for performance.
+[`picoquery`](https://github.com/43081j/picoquery) supports nesting and arrays with a fast single‑pass parser and configurable syntax. v2.x and above are ESM‑only; v1.x is CommonJS and will be maintained with non‑breaking changes. `nestingSyntax: 'js'` offers the highest compatibility with `qs`, though you can pick other syntaxes for performance.
 
 Example:
 
@@ -67,7 +67,7 @@ const str = stringify({ user: { name: 'foo' }, tags: ['bar', 'baz'] }, opts) // 
 
 ## `neoqs`
 
-[`neoqs`](https://www.npmjs.com/package/neoqs) is a fork of `qs` without legacy polyfills, with TypeScript types included, and with both ESM and CommonJS builds (plus a legacy ES5 mode). Choose it when you want `qs`‑level compatibility with modern packaging options.
+[`neoqs`](https://github.com/PuruVJ/neoqs) is a fork of `qs` without legacy polyfills, with TypeScript types included, and with both ESM and CommonJS builds (plus a legacy ES5 mode). Choose it when you want `qs`‑level compatibility with modern packaging options.
 
 Example:
 

--- a/docs/modules/readable-stream.md
+++ b/docs/modules/readable-stream.md
@@ -4,7 +4,7 @@ description: Modern alternatives to the readable-stream package for working with
 
 # Replacements for `readable-stream`
 
-[`readable-stream`](https://www.npmjs.com/package/readable-stream) mirrors Node’s core streams and works in browsers. In most cases, prefer native options.
+[`readable-stream`](https://github.com/nodejs/readable-stream) mirrors Node’s core streams and works in browsers. In most cases, prefer native options.
 
 ## `node:stream` (native, since Node.js v0.9.4)
 

--- a/docs/modules/resolve.md
+++ b/docs/modules/resolve.md
@@ -16,7 +16,7 @@ const path = import.meta.resolve('my-module')
 
 ## `exsolve`
 
-[`exsolve`](https://www.npmjs.com/package/exsolve)
+[`exsolve`](https://github.com/unjs/exsolve)
 
 ```ts
 import { resolveModulePath } from 'exsolve'
@@ -26,7 +26,7 @@ const path = resolveModulePath('my-module')
 
 ## `oxc-resolver`
 
-[`oxc-resolver`](https://www.npmjs.com/package/oxc-resolver)
+[`oxc-resolver`](https://github.com/oxc-project/oxc-resolver)
 
 ```ts
 import { ResolverFactory } from 'oxc-resolver'

--- a/docs/modules/sort-object.md
+++ b/docs/modules/sort-object.md
@@ -48,7 +48,7 @@ const sorted = Object.fromEntries( // [!code ++]
 
 ## `sort-object-keys`
 
-[`sort-object-keys`](https://www.npmjs.com/package/sort-object-keys) is zero‑dependency and matches common `sort-object` use cases (custom order array or comparator).
+[`sort-object-keys`](https://github.com/keithamus/sort-object-keys) is zero‑dependency and matches common `sort-object` use cases (custom order array or comparator).
 
 ```ts
 import sortObj from 'sort-object' // [!code --]
@@ -65,7 +65,7 @@ const sortedByCmp = sortObjectKeys(object, (a, b) => a.localeCompare(b)) // [!co
 
 ## `sortobject`
 
-[`sortobject`](https://www.npmjs.com/package/sortobject) is zero‑dependency and deeply sorts nested objects.
+[`sortobject`](https://github.com/bevry/sortobject) is zero‑dependency and deeply sorts nested objects.
 
 ```ts
 import sortObj from 'sort-object' // [!code --]

--- a/docs/templates/module.md
+++ b/docs/templates/module.md
@@ -9,5 +9,3 @@
 {Description of alternative package}
 
 [Project Page](https://github.com)
-
-[npm](https://npmjs.com)


### PR DESCRIPTION
This PR standardizes URLs across the replacement modules files to link directly to GitHub repositories instead of npm.
- Replaces URLs in 8 module files
- Removes npm reference from the module template file. In the future this could be replaced by a link or badge to npmx.