### PR TITLE
chore: use import attributes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,11 @@
-import {readFileSync} from 'node:fs';
-import {ManifestModule} from './types.js';
-import {manifestsDir} from './manifests-dir.js';
+import nativeRaw from '../manifests/native.json' with {type: 'json'};
+import microUtilsRaw from '../manifests/micro-utilities.json' with {type: 'json'};
+import preferredRaw from '../manifests/preferred.json' with {type: 'json'};
+import type {ManifestModule} from './types.js';
 
-const nativeReplacements = JSON.parse(
-  readFileSync(`${manifestsDir}/native.json`, 'utf8')
-) as ManifestModule;
-const microUtilsReplacements = JSON.parse(
-  readFileSync(`${manifestsDir}/micro-utilities.json`, 'utf8')
-) as ManifestModule;
-const preferredReplacements = JSON.parse(
-  readFileSync(`${manifestsDir}/preferred.json`, 'utf8')
-) as ManifestModule;
+const nativeReplacements = nativeRaw as ManifestModule;
+const microUtilsReplacements = microUtilsRaw as ManifestModule;
+const preferredReplacements = preferredRaw as ManifestModule;
 
 export * from './types.js';
 export * from './util.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2020",
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "resolveJsonModule": true,
     "types": ["node"],
     "declaration": true,
     "isolatedModules": true,


### PR DESCRIPTION
Instead of reading from disk, we can use imports with JSON files in node
20 and above.

This does mean we drop node 18 support if we merge this.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
