### PR TITLE
docs: add backticks around code snippets in descriptions

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -3,13 +3,13 @@
     "snippet::array-coerce": {
       "id": "snippet::array-coerce",
       "type": "simple",
-      "description": "You can use a combination of a ternary operator and Array.isArray to make sure a value, undefined, null or an array is always returned as an array.",
+      "description": "You can use a combination of a ternary operator and `Array.isArray` to make sure a value, `undefined`, `null` or an array is always returned as an array.",
       "example": "(arr == null ? [] : Array.isArray(arr) ? arr : [arr])"
     },
     "snippet::array-difference": {
       "id": "snippet::array-difference",
       "type": "simple",
-      "description": "You can use a combination of filter and includes to calculate the difference between two arrays.",
+      "description": "You can use a combination of `filter` and `includes` to calculate the difference between two arrays.",
       "example": "const difference = (a, b) => a.filter((item) => !b.includes(item))"
     },
     "snippet::array-from-count": {
@@ -33,13 +33,13 @@
     "snippet::array-union": {
       "id": "snippet::array-union",
       "type": "simple",
-      "description": "You can use a combination of the spread operator and Set to create a union of two arrays.",
+      "description": "You can use a combination of the spread operator and `Set` to create a union of two arrays.",
       "example": "const union = (a, b) => [...new Set([...a, ...b])]"
     },
     "snippet::array-unique": {
       "id": "snippet::array-unique",
       "type": "simple",
-      "description": "You can convert to and from a Set to remove duplicates from an array.",
+      "description": "You can convert to and from a `Set` to remove duplicates from an array.",
       "example": "const unique = (arr) => [...new Set(arr)]"
     },
     "snippet::async-function-constructor": {
@@ -57,7 +57,7 @@
     "snippet::call-bind": {
       "id": "snippet::call-bind",
       "type": "simple",
-      "description": "Every modern runtime provides a way to bind to the call method of a function.",
+      "description": "Every modern runtime provides a way to bind to the `call` method of a function.",
       "example": "const fnBound = Function.call.bind(fn)"
     },
     "snippet::char-last": {
@@ -75,13 +75,13 @@
     "snippet::get-iterator": {
       "id": "snippet::get-iterator",
       "type": "simple",
-      "description": "Every modern runtime provides a way to get the iterator function through the Symbol.iterator symbol.",
+      "description": "Every modern runtime provides a way to get the iterator function through the `Symbol.iterator` symbol.",
       "example": "const iterator = obj[Symbol.iterator]?.()"
     },
     "snippet::has-argv": {
       "id": "snippet::has-argv",
       "type": "simple",
-      "description": "You can use the includes method on the process.argv array to check if a flag is present.",
+      "description": "You can use the `includes` method on the `process.argv` array to check if a flag is present.",
       "example": "process.argv.includes('--flag')"
     },
     "snippet::is-arguments": {
@@ -93,7 +93,7 @@
     "snippet::is-arraybuffer": {
       "id": "snippet::is-arraybuffer",
       "type": "simple",
-      "description": "You can use `instanceof ArrayBuffer`, or if cross-realm, use Object.prototype.toString.call(obj) === \"[object ArrayBuffer]\"",
+      "description": "You can use `instanceof ArrayBuffer`, or if cross-realm, use `Object.prototype.toString.call(obj) === \"[object ArrayBuffer]\"`",
       "example": "const isArrayBuffer = obj instanceof ArrayBuffer;\n// for cross-realm\nconst isArrayBufferCrossRealm = Object.prototype.toString.call(obj) === \"[object ArrayBuffer]\""
     },
     "snippet::is-async-function": {
@@ -111,19 +111,19 @@
     "snippet::is-boolean": {
       "id": "snippet::is-boolean",
       "type": "simple",
-      "description": "You can use typeof to check if a value is a boolean primitive, and Object.prototype.toString.call to check if it's a Boolean object.",
+      "description": "You can use `typeof` to check if a value is a boolean primitive, and `Object.prototype.toString.call` to check if it's a `Boolean` object.",
       "example": "Object.prototype.toString.call(v) === \"[object Boolean]\""
     },
     "snippet::is-ci": {
       "id": "snippet::is-ci",
       "type": "simple",
-      "description": "Every major CI provider sets a CI environment variable that you can use to detect if you're running in a CI environment.",
+      "description": "Every major CI provider sets a `CI` environment variable that you can use to detect if you're running in a CI environment.",
       "example": "Boolean(process.env.CI)"
     },
     "snippet::is-date": {
       "id": "snippet::is-date",
       "type": "simple",
-      "description": "You can use `instanceof Date`, or if cross-realm, use Object.prototype.toString.call(v) === \"[object Date]\"",
+      "description": "You can use `instanceof Date`, or if cross-realm, use `Object.prototype.toString.call(v) === \"[object Date]\"`",
       "example": "const isDate = v instanceof Date;\n// for cross-realm\nconst isDateCrossRealm = Object.prototype.toString.call(v) === \"[object Date]\""
     },
     "snippet::is-even": {
@@ -159,7 +159,7 @@
     "snippet::is-npm": {
       "id": "snippet::is-npm",
       "type": "simple",
-      "description": "If the current environment is npm the `npm_config_user_agent` environment variable will be set and start with \"npm\".",
+      "description": "If the current environment is npm the `npm_config_user_agent` environment variable will be set and start with `\"npm\"`.",
       "example": "const isNpm = process.env.npm_config_user_agent?.startsWith(\"npm\")"
     },
     "snippet::is-object": {
@@ -183,7 +183,7 @@
     "snippet::is-primitve": {
       "id": "snippet::is-primitve",
       "type": "simple",
-      "description": "You can check `typeof` of a value to determine if it's a primitive. Note that `typeof null` is \"object\" so you need to check for null separately.",
+      "description": "You can check `typeof` of a value to determine if it's a primitive. Note that `typeof null` is `\"object\"` so you need to check for `null` separately.",
       "example": "const isPrimitive = (value) => value === null || (typeof value !== \"function\" && typeof value !== \"object\");"
     },
     "snippet::is-regexp": {
@@ -231,7 +231,7 @@
     "snippet::json-file": {
       "id": "snippet::json-file",
       "type": "simple",
-      "description": "You can use `JSON` and 'node:fs' to read and write json file.",
+      "description": "You can use `JSON` and `node:fs` to read and write JSON files.",
       "example": "import * as fs from 'node:fs/promises'\nfs.readFile(file, 'utf8').then(JSON.parse)\nfs.writeFile(file, JSON.stringify(data, null, 2) + '\\n')"
     },
     "snippet::math-random": {

--- a/manifests/native.json
+++ b/manifests/native.json
@@ -897,7 +897,7 @@
     "Object.assign": {
       "id": "Object.assign",
       "type": "native",
-      "description": "Object.assign, or if deep clones are needed, use structuredClone",
+      "description": "`Object.assign`, or if deep clones are needed, use `structuredClone`",
       "url": {
         "type": "mdn",
         "id": "Web/JavaScript/Reference/Global_Objects/Object/assign"
@@ -1404,7 +1404,7 @@
     "es-errors": {
       "id": "es-errors",
       "type": "removal",
-      "description": "Error and its subclasses are natively built into all modern environments.",
+      "description": "`Error` and its subclasses are natively built into all modern environments.",
       "url": {
         "type": "mdn",
         "id": "Web/JavaScript/Reference/Global_Objects/Error"
@@ -1413,7 +1413,7 @@
     "es-string-html-methods": {
       "id": "es-string-html-methods",
       "type": "removal",
-      "description": "All the methods exported by this modules are generally available on the String prototype in modern environments.",
+      "description": "All the methods exported by this modules are generally available on the `String` prototype in modern environments.",
       "url": {
         "type": "mdn",
         "id": "Web/JavaScript/Reference/Global_Objects/String#html_wrapper_methods"
@@ -1439,7 +1439,7 @@
     "for...of": {
       "id": "for...of",
       "type": "native",
-      "description": "for...of (using \"Object.entries\" if dealing with objects)",
+      "description": "`for...of` (using `Object.entries` if dealing with objects)",
       "url": {
         "type": "mdn",
         "id": "Web/JavaScript/Reference/Statements/for...of"
@@ -1482,7 +1482,7 @@
     "has-bigints": {
       "id": "has-bigints",
       "type": "removal",
-      "description": "Every modern environment has support for BigInt. You can just remove the check.",
+      "description": "Every modern environment has support for `BigInt`. You can just remove the check.",
       "url": {
         "type": "mdn",
         "id": "Web/JavaScript/Reference/Global_Objects/BigInt"
@@ -1491,7 +1491,7 @@
     "has-dynamic-import": {
       "id": "has-dynamic-import",
       "type": "removal",
-      "description": "Every modern environment has support for dynamic import. You can just remove the check.",
+      "description": "Every modern environment has support for dynamic `import()`. You can just remove the check.",
       "url": {
         "type": "mdn",
         "id": "Web/JavaScript/Reference/Operators/import"
@@ -1518,7 +1518,7 @@
     "has-proto": {
       "id": "has-proto",
       "type": "removal",
-      "description": "Every modern environment has support for __proto__. You can just remove the check.",
+      "description": "Every modern environment has support for `__proto__`. You can just remove the check.",
       "url": {
         "type": "mdn",
         "id": "Web/JavaScript/Reference/Operators/Object_initializer#prototype_setter"
@@ -1527,7 +1527,7 @@
     "has-symbols": {
       "id": "has-symbols",
       "type": "removal",
-      "description": "Every modern environment has support for Symbols. You can just remove the check.",
+      "description": "Every modern environment has support for `Symbol`. You can just remove the check.",
       "url": {
         "type": "mdn",
         "id": "Web/JavaScript/Reference/Global_Objects/Symbol"

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2999,7 +2999,6 @@
     "fs": {
       "id": "fs",
       "type": "native",
-      "description": "Node file system module",
       "nodeFeatureId": {"moduleName": "node:fs"},
       "url": {"type": "node", "id": "api/fs.html"}
     },
@@ -3288,7 +3287,6 @@
     "readline.createInterface": {
       "id": "readline.createInterface",
       "type": "native",
-      "description": "readline.createInterface",
       "nodeFeatureId": {
         "moduleName": "node:readline",
         "exportName": "createInterface"
@@ -3307,7 +3305,7 @@
     "sort-object": {
       "id": "sort-object",
       "type": "removal",
-      "description": "Object.entries and Array.prototype.sort can be used to sort object keys.",
+      "description": "`Object.entries` and `Array.prototype.sort` can be used to sort object keys.",
       "url": {"type": "e18e", "id": "sort-object"}
     },
     "sort-object-keys": {


### PR DESCRIPTION
This means things like npmx can render the descriptions as markdown.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
