### PR TITLE
fix: update types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ interface ModuleReplacementLike {
 export interface DocumentedModuleReplacement extends ModuleReplacementLike {
   type: 'documented';
   url: KnownUrl;
+  description?: never;
   replacementModule: string;
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Add `description?: never` to `DocumentedModuleReplacement` for easier use with typescript


This is to avoid doing things like this:

https://github.com/npmx-dev/npmx.dev/blob/d80c709c30b41ac68bb91b6524fabe59477417d2/app/components/Package/Replacement.vue#L17-L19