### PR TITLE
feat: add `es5-shim` and `es6-shim` to native manifest

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -1422,12 +1422,12 @@
     "es5-shim": {
       "id": "es5-shim",
       "type": "removal",
-      "description": "Every modern environment has support for ES5 apis."
+      "description": "Every modern environment has support for ES5 APIs."
     },
     "es6-shim": {
       "id": "es6-shim",
       "type": "removal",
-      "description": "Every modern environment has support for ES6/ES2015 apis."
+      "description": "Every modern environment has support for ES6/ES2015 APIs."
     },
     "es7-shim": {
       "id": "es7-shim",


### PR DESCRIPTION
### 🔗 Linked issue

Follow up to #426


### 📚 Description

add `es5-shim` and `es6-shim` to native manifest with `"removal"` type
