### PR TITLE
fix: set all runtimes minVersion to 0.0.1

### DIFF
--- a/scripts/update-engines-runtimes.ts
+++ b/scripts/update-engines-runtimes.ts
@@ -68,7 +68,11 @@ function isFeatureSupported(
   moduleName: string,
   exportName?: string
 ): boolean {
-  const moduleSupport = runtimeData.builtinModules[moduleName];
+  let moduleSupport = runtimeData.builtinModules[moduleName];
+
+  if (moduleSupport === undefined && !moduleName.startsWith('node:')) {
+    moduleSupport = runtimeData.builtinModules[`node:${moduleName}`];
+  }
 
   if (moduleSupport === false || moduleSupport === undefined) {
     return false;
@@ -105,7 +109,7 @@ function extractRuntimeEngines(
     if (isFeatureSupported(runtimeData, moduleName, exportName)) {
       engines.push({
         engine: runtimeName,
-        minVersion: runtimeData.version
+        minVersion: '0.0.1' // Assuming all versions support it
       });
     }
   }


### PR DESCRIPTION
The version is currently the latest version of node that these engines
were tested again, rather than the version of the engine that added
support.

This fixes it so the version is hard coded as `0.0.1` since we don't
know which one introduced each feature.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
