### PR TITLE
feat: add `year` package to replacements

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -311,6 +311,12 @@
       "type": "simple",
       "description": "You can check the start of a path for the Windows extended-length path prefix and if it's not present, replace backslashes with forward slashes.",
       "example": "path.startsWith('\\\\\\\\?\\\\') ? path : path.replace(/\\\\/g, '/')"
+    },
+    "snippet::year": {
+      "id": "snippet::year",
+      "type": "simple",
+      "description": "You can use `new Date().getUTCFullYear()` to get the current year.",
+      "example": "new Date().getUTCFullYear()"
     }
   },
   "mappings": {
@@ -482,12 +488,12 @@
     "is-number": {
       "type": "module",
       "moduleName": "is-number",
-      "replacements": ["snippet:is-number"]
+      "replacements": ["snippet::is-number"]
     },
     "is-number-object": {
       "type": "module",
       "moduleName": "is-number-object",
-      "replacements": ["snippet:is-number"]
+      "replacements": ["snippet::is-number"]
     },
     "is-obj": {
       "type": "module",
@@ -643,6 +649,11 @@
       "type": "module",
       "moduleName": "upper-case",
       "replacements": ["snippet::to-uppercase"]
+    },
+    "year": {
+      "type": "module",
+      "moduleName": "year",
+      "replacements": ["snippet::year"]
     }
   }
 }

--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -162,6 +162,12 @@
       "description": "If the current environment is npm the `npm_config_user_agent` environment variable will be set and start with `\"npm\"`.",
       "example": "const isNpm = process.env.npm_config_user_agent?.startsWith(\"npm\")"
     },
+    "snippet::is-number": {
+      "id": "snippet::is-number",
+      "type": "simple",
+      "description": "You can check if a value is a number by using `typeof` or coercing it to a number and using `Number.isFinite`.",
+      "example": "const isNumber = (v) => typeof v === \"number\" || (typeof v === \"string\" && Number.isFinite(+v));"
+    },
     "snippet::is-object": {
       "id": "snippet::is-object",
       "type": "simple",
@@ -305,12 +311,6 @@
       "type": "simple",
       "description": "You can check the start of a path for the Windows extended-length path prefix and if it's not present, replace backslashes with forward slashes.",
       "example": "path.startsWith('\\\\\\\\?\\\\') ? path : path.replace(/\\\\/g, '/')"
-    },
-    "snippet:is-number": {
-      "id": "snippet:is-number",
-      "type": "simple",
-      "description": "You can check if a value is a number by using `typeof` or coercing it to a number and using `Number.isFinite`.",
-      "example": "const isNumber = (v) => typeof v === \"number\" || (typeof v === \"string\" && Number.isFinite(+v));"
     }
   },
   "mappings": {

--- a/scripts/validate-manifests.js
+++ b/scripts/validate-manifests.js
@@ -30,37 +30,6 @@ export async function validateManifests() {
       throw new Error(`Validation for ${manifestPath} failed!`);
     }
 
-    for (const [id, replacement] of Object.entries(manifest.replacements)) {
-      if (replacement.id !== id) {
-        throw new Error(
-          `${manifestPath}: replacement key "${id}" does not match its id property "${replacement.id}"`
-        );
-      }
-
-      if (replacement.type === 'simple' && !id.startsWith('snippet::')) {
-        throw new Error(
-          `${manifestPath}: replacement "${id}" is type "simple" and must start with the "snippet::" prefix.`
-        );
-      }
-
-      if (!replacement.webFeatureId) continue;
-
-      const {featureId, compatKey} = replacement.webFeatureId;
-      const feature = webFeatures[featureId];
-
-      if (!feature) {
-        throw new Error(
-          `${manifestPath}: replacement "${id}" has unknown webFeatureId.featureId "${featureId}"`
-        );
-      }
-
-      if (!feature.compat_features?.includes(compatKey)) {
-        throw new Error(
-          `${manifestPath}: replacement "${id}" has compatKey "${compatKey}" not found in web-features feature "${featureId}"`
-        );
-      }
-    }
-
     const usedReplacementIds = new Set();
 
     for (const [key, mapping] of Object.entries(manifest.mappings)) {
@@ -89,10 +58,39 @@ export async function validateManifests() {
       }
     }
 
-    for (const id of Object.keys(manifest.replacements)) {
+    for (const [id, replacement] of Object.entries(manifest.replacements)) {
+      if (replacement.id !== id) {
+        throw new Error(
+          `${manifestPath}: replacement key "${id}" does not match its id property "${replacement.id}"`
+        );
+      }
+
       if (!usedReplacementIds.has(id)) {
         throw new Error(
           `${manifestPath}: replacement "${id}" is defined but not used by any mapping.`
+        );
+      }
+
+      if (replacement.type === 'simple' && !id.startsWith('snippet::')) {
+        throw new Error(
+          `${manifestPath}: replacement "${id}" is type "simple" and must start with the "snippet::" prefix.`
+        );
+      }
+
+      if (!replacement.webFeatureId) continue;
+
+      const {featureId, compatKey} = replacement.webFeatureId;
+      const feature = webFeatures[featureId];
+
+      if (!feature) {
+        throw new Error(
+          `${manifestPath}: replacement "${id}" has unknown webFeatureId.featureId "${featureId}"`
+        );
+      }
+
+      if (!feature.compat_features?.includes(compatKey)) {
+        throw new Error(
+          `${manifestPath}: replacement "${id}" has compatKey "${compatKey}" not found in web-features feature "${featureId}"`
         );
       }
     }

--- a/scripts/validate-manifests.js
+++ b/scripts/validate-manifests.js
@@ -53,6 +53,12 @@ export async function validateManifests() {
           `${manifestPath}: replacement "${id}" has compatKey "${compatKey}" not found in web-features feature "${featureId}"`
         );
       }
+
+      if (replacement.type === 'simple' && !id.startsWith('snippet::')) {
+        throw new Error(
+          `${manifestPath}: replacement "${id}" is type "simple" and must start with the "snippet::" prefix.`
+        );
+      }
     }
 
     const usedReplacementIds = new Set();

--- a/scripts/validate-manifests.js
+++ b/scripts/validate-manifests.js
@@ -37,6 +37,12 @@ export async function validateManifests() {
         );
       }
 
+      if (replacement.type === 'simple' && !id.startsWith('snippet::')) {
+        throw new Error(
+          `${manifestPath}: replacement "${id}" is type "simple" and must start with the "snippet::" prefix.`
+        );
+      }
+
       if (!replacement.webFeatureId) continue;
 
       const {featureId, compatKey} = replacement.webFeatureId;
@@ -51,12 +57,6 @@ export async function validateManifests() {
       if (!feature.compat_features?.includes(compatKey)) {
         throw new Error(
           `${manifestPath}: replacement "${id}" has compatKey "${compatKey}" not found in web-features feature "${featureId}"`
-        );
-      }
-
-      if (replacement.type === 'simple' && !id.startsWith('snippet::')) {
-        throw new Error(
-          `${manifestPath}: replacement "${id}" is type "simple" and must start with the "snippet::" prefix.`
         );
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #554


### 📚 Description

- add `year` package to replacements
- validate "simple" replacement id starts with `snippet::`
