### PR TITLE
feat: add `arraybuffer.slice` to native manifest

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -1869,6 +1869,11 @@
       "moduleName": "arraybuffer.prototype.slice",
       "replacements": ["ArrayBuffer.prototype.slice"]
     },
+    "arraybuffer.slice": {
+      "type": "module",
+      "moduleName": "arraybuffer.slice",
+      "replacements": ["ArrayBuffer.prototype.slice"]
+    },
     "asynciterator.prototype": {
       "type": "module",
       "moduleName": "asynciterator.prototype",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #570


### 📚 Description

add `arraybuffer.slice` to native manifest
