### PR TITLE
chore: format manifests

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -75,10 +75,7 @@
     "AbortController": {
       "id": "AbortController",
       "type": "native",
-      "url": {
-        "type": "mdn",
-        "id": "Web/API/AbortController"
-      },
+      "url": {"type": "mdn", "id": "Web/API/AbortController"},
       "webFeatureId": {
         "featureId": "aborting",
         "compatKey": "api.AbortController.AbortController"
@@ -657,14 +654,8 @@
     "EventTarget": {
       "id": "EventTarget",
       "type": "native",
-      "url": {
-        "type": "mdn",
-        "id": "Web/API/EventTarget"
-      },
-      "webFeatureId": {
-        "featureId": "events",
-        "compatKey": "api.EventTarget"
-      }
+      "url": {"type": "mdn", "id": "Web/API/EventTarget"},
+      "webFeatureId": {"featureId": "events", "compatKey": "api.EventTarget"}
     },
     "Function.prototype.bind": {
       "id": "Function.prototype.bind",
@@ -1390,14 +1381,8 @@
     "URL": {
       "id": "URL",
       "type": "native",
-      "url": {
-        "type": "mdn",
-        "id": "Web/API/URL"
-      },
-      "webFeatureId": {
-        "featureId": "url",
-        "compatKey": "api.URL"
-      }
+      "url": {"type": "mdn", "id": "Web/API/URL"},
+      "webFeatureId": {"featureId": "url", "compatKey": "api.URL"}
     },
     "WeakMap": {
       "id": "WeakMap",
@@ -1419,10 +1404,7 @@
     "atob": {
       "id": "atob",
       "type": "native",
-      "url": {
-        "type": "mdn",
-        "id": "Web/API/Window/atob"
-      },
+      "url": {"type": "mdn", "id": "Web/API/Window/atob"},
       "webFeatureId": {
         "featureId": "base64encodedecode",
         "compatKey": "api.atob"
@@ -1431,10 +1413,7 @@
     "btoa": {
       "id": "btoa",
       "type": "native",
-      "url": {
-        "type": "mdn",
-        "id": "Web/API/Window/btoa"
-      },
+      "url": {"type": "mdn", "id": "Web/API/Window/btoa"},
       "webFeatureId": {
         "featureId": "base64encodedecode",
         "compatKey": "api.btoa"
@@ -1443,10 +1422,7 @@
     "crypto.timingSafeEqual": {
       "id": "crypto.timingSafeEqual",
       "type": "native",
-      "url": {
-        "type": "node",
-        "id": "api/crypto.html#cryptotimingsafeequala-b"
-      },
+      "url": {"type": "node", "id": "api/crypto.html#cryptotimingsafeequala-b"},
       "nodeFeatureId": {"moduleName": "crypto", "exportName": "timingSafeEqual"}
     },
     "es-errors": {
@@ -1519,10 +1495,7 @@
     "fs.rm": {
       "id": "fs.rm",
       "type": "native",
-      "url": {
-        "type": "node",
-        "id": "api/fs.html#fsrmpath-options-callback"
-      },
+      "url": {"type": "node", "id": "api/fs.html#fsrmpath-options-callback"},
       "nodeFeatureId": {"moduleName": "fs"}
     },
     "fsPromises": {
@@ -1556,10 +1529,7 @@
       "id": "has-dynamic-import",
       "type": "removal",
       "description": "Every modern environment has support for dynamic `import()`. You can just remove the check.",
-      "url": {
-        "type": "mdn",
-        "id": "Web/JavaScript/Reference/Operators/import"
-      }
+      "url": {"type": "mdn", "id": "Web/JavaScript/Reference/Operators/import"}
     },
     "has-optional-chaining": {
       "id": "has-optional-chaining",
@@ -1601,10 +1571,7 @@
       "id": "has-template-literals",
       "type": "removal",
       "description": "Every modern environment has support for template literals. You can just remove the check.",
-      "url": {
-        "type": "mdn",
-        "id": "Web/JavaScript/Reference/Template_literals"
-      }
+      "url": {"type": "mdn", "id": "Web/JavaScript/Reference/Template_literals"}
     },
     "has-tostringtag": {
       "id": "has-tostringtag",
@@ -1639,19 +1606,13 @@
     "path.parse": {
       "id": "path.parse",
       "type": "native",
-      "url": {
-        "type": "node",
-        "id": "api/path.html#pathparsepath"
-      },
+      "url": {"type": "node", "id": "api/path.html#pathparsepath"},
       "nodeFeatureId": {"moduleName": "path"}
     },
     "queueMicrotask": {
       "id": "queueMicrotask",
       "type": "native",
-      "url": {
-        "type": "mdn",
-        "id": "Web/API/Window/queueMicrotask"
-      },
+      "url": {"type": "mdn", "id": "Web/API/Window/queueMicrotask"},
       "webFeatureId": {
         "featureId": "queuemicrotask",
         "compatKey": "api.queueMicrotask"
@@ -1675,19 +1636,13 @@
     "util.promisify": {
       "id": "util.promisify",
       "type": "native",
-      "url": {
-        "type": "node",
-        "id": "api/util.html#utilpromisifyoriginal"
-      },
+      "url": {"type": "node", "id": "api/util.html#utilpromisifyoriginal"},
       "nodeFeatureId": {"moduleName": "util", "exportName": "promisify"}
     },
     "zlib.crc32": {
       "id": "zlib.crc32",
       "type": "native",
-      "url": {
-        "type": "node",
-        "id": "api/zlib.html#zlibcrc32data-value"
-      },
+      "url": {"type": "node", "id": "api/zlib.html#zlibcrc32data-value"},
       "nodeFeatureId": {"moduleName": "zlib", "exportName": "crc32"}
     }
   },
@@ -1912,21 +1867,13 @@
       "moduleName": "asynciterator.prototype",
       "replacements": ["AsyncIterator.prototype"]
     },
-    "atob": {
-      "type": "module",
-      "moduleName": "atob",
-      "replacements": ["atob"]
-    },
+    "atob": {"type": "module", "moduleName": "atob", "replacements": ["atob"]},
     "atob-lite": {
       "type": "module",
       "moduleName": "atob-lite",
       "replacements": ["atob"]
     },
-    "btoa": {
-      "type": "module",
-      "moduleName": "btoa",
-      "replacements": ["btoa"]
-    },
+    "btoa": {"type": "module", "moduleName": "btoa", "replacements": ["btoa"]},
     "buffer-crc32": {
       "type": "module",
       "moduleName": "buffer-crc32",


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

Formats the manifests to avoid some prettier inconsistency that makes `sort-manifests` cause conflicts.
