### PR TITLE
docs: Add links to Node.js API docs in various module replacements pages.

### DIFF
--- a/docs/modules/buf-compare.md
+++ b/docs/modules/buf-compare.md
@@ -6,7 +6,7 @@ description: Native Node.js alternatives to the buf-compare package for buffer c
 
 ## `Buffer.compare` (native)
 
-`Buffer.compare` is a native method which achieves the same result as `buf-compare`, available since Node v0.11.13.
+[`Buffer.compare`](https://nodejs.org/api/buffer.html#static-method-buffercomparebuf1-buf2) is a native method which achieves the same result as `buf-compare`, available since Node v0.11.13.
 
 Example:
 

--- a/docs/modules/buffer-equal.md
+++ b/docs/modules/buffer-equal.md
@@ -6,7 +6,7 @@ description: Native Node.js alternatives to the buffer-equal package for buffer 
 
 ## `Buffer#equals` (native)
 
-Buffers have an `equals` method since Node 0.12.
+Buffers have an [`equals`](https://nodejs.org/api/buffer.html#bufequalsotherbuffer) method since Node v0.12.
 
 Example:
 

--- a/docs/modules/buffer-equals.md
+++ b/docs/modules/buffer-equals.md
@@ -6,7 +6,7 @@ description: Native Node.js alternatives to the buffer-equals package for buffer
 
 ## `Buffer#equals` (native)
 
-Buffers have an `equals` method since Node 0.12.
+Buffers have an [`equals`](https://nodejs.org/api/buffer.html#bufequalsotherbuffer) method since Node v0.12.
 
 Example:
 

--- a/docs/modules/builtin-modules.md
+++ b/docs/modules/builtin-modules.md
@@ -6,7 +6,7 @@ description: Native Node.js alternatives to the builtin-modules package for list
 
 ## `builtinModules` (native, since Node.js 6.x)
 
-For getting the list of built-in modules, you can use [builtinModules](https://nodejs.org/api/module.html#modulebuiltinmodules):
+For getting the list of built-in modules, you can use [`builtinModules`](https://nodejs.org/api/module.html#modulebuiltinmodules):
 
 ```ts
 import builtinModulesList from 'builtin-modules' // [!code --]

--- a/docs/modules/fs-extra.md
+++ b/docs/modules/fs-extra.md
@@ -6,7 +6,7 @@ description: Modern alternatives to the fs-extra package for working with the fi
 
 ## `fs` and `fs/promises` (native, Node.js)
 
-Modern Node.js includes built-in `fs` and `fs/promises` APIs that cover what [`fs-extra`](https://github.com/jprichardson/node-fs-extra) historically provided.
+Modern Node.js includes built-in [`fs`](https://nodejs.org/api/fs.html) and [`fs/promises`](https://nodejs.org/api/fs.html#promises-api) APIs that cover what [`fs-extra`](https://github.com/jprichardson/node-fs-extra) historically provided.
 
 ```js
 import fsExtra from 'fs-extra' // [!code --]

--- a/docs/modules/get-stream.md
+++ b/docs/modules/get-stream.md
@@ -20,7 +20,7 @@ async function streamToString(stream) {
 
 ## Converting stream to Array
 
-You can convert a stream to an array using `Array.fromAsync`:
+You can convert a stream to an array using [`Array.fromAsync`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync) in Node 22+:
 
 ```ts
 await Array.fromAsync(stream)
@@ -38,7 +38,7 @@ async function streamToArray(stream) {
 
 ## Converting stream to Buffer
 
-You can convert a stream to a `Buffer` using `Array.fromAsync` with a mapper:
+You can convert a stream to a `Buffer` using [`Array.fromAsync`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync) with a mapper:
 
 ```ts
 async function streamToBuffer(stream) {

--- a/docs/modules/inherits.md
+++ b/docs/modules/inherits.md
@@ -6,7 +6,7 @@ description: Modern alternatives to the inherits package
 
 ## ES6 classes `extends` syntax
 
-ES6 classes `extends` syntax is a native way to implement prototype inheritance.
+ES6 classes [`extends`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends) syntax is a native way to implement prototype inheritance.
 
 Example:
 

--- a/docs/modules/md5.md
+++ b/docs/modules/md5.md
@@ -6,7 +6,9 @@ description: Native Node.js alternatives to the md5 package for MD5 hash generat
 
 ## `crypto` (native)
 
-If you're using the [`md5`](https://github.com/pvorb/node-md5) package, consider using a stronger algorithm where possible. If you must keep MD5 for compatibility, Node.js provides a native alternative via the `crypto` module.
+If you're using the [`md5`](https://github.com/pvorb/node-md5) package, _strongly_ consider moving to a stronger algorithm if your usage is security-sensitive (for example, passwords). MD5 is [not secure](https://en.wikipedia.org/wiki/MD5#Security) and hasn't been for many many years.
+
+If you must keep MD5 for compatibility, Node.js provides a native alternative via the [`crypto` module](https://nodejs.org/api/crypto.html#crypto).
 
 ```ts
 import crypto from 'node:crypto' // [!code ++]

--- a/docs/modules/md5.md
+++ b/docs/modules/md5.md
@@ -6,7 +6,7 @@ description: Native Node.js alternatives to the md5 package for MD5 hash generat
 
 ## `crypto` (native)
 
-If you're using the [`md5`](https://github.com/pvorb/node-md5) package, _strongly_ consider moving to a stronger algorithm if your usage is security-sensitive (for example, passwords). MD5 is [not secure](https://en.wikipedia.org/wiki/MD5#Security) and hasn't been for many many years.
+If you're using the [`md5`](https://github.com/pvorb/node-md5) package, _strongly_ consider moving to a stronger algorithm if your usage is security-sensitive (for example, passwords). MD5 is [not secure](https://en.wikipedia.org/wiki/MD5#Security) and hasn't been secure for many years.
 
 If you must keep MD5 for compatibility, Node.js provides a native alternative via the [`crypto` module](https://nodejs.org/api/crypto.html#crypto).
 

--- a/docs/modules/object-hash.md
+++ b/docs/modules/object-hash.md
@@ -20,7 +20,7 @@ const h = hash(obj) // [!code ++]
 
 ## Web Crypto
 
-Use the standard `SubtleCrypto.digest` available in modern runtimes. Pair it with a stable serializer (e.g., [`safe-stable-stringify`](https://github.com/BridgeAR/safe-stable-stringify)) to ensure deterministic key ordering.
+Use the standard [`SubtleCrypto.digest`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest) available in modern runtimes. Pair it with a stable serializer (e.g., [`safe-stable-stringify`](https://github.com/BridgeAR/safe-stable-stringify)) to ensure deterministic key ordering.
 
 Example:
 

--- a/docs/modules/split.md
+++ b/docs/modules/split.md
@@ -6,12 +6,16 @@ description: Native Node.js alternatives to the split package for splitting stre
 
 ## `readline.createInterface` (native, since Node.js v6.6.0)
 
+The [`readline.createInterface`](https://nodejs.org/api/readline.html#readlinecreateinterfaceoptions)
+method can be used to read a stream line by line, effectively replacing the functionality of the `split` package.
+
 Example:
 
 <!-- prettier-ignore -->
 ```js
 import split from 'split' // [!code --]
 import { createInterface } from 'node:readline' // [!code ++]
+import fs from 'node:fs'
 
 const input = fs.createReadStream('file.txt')
 

--- a/docs/modules/split.md
+++ b/docs/modules/split.md
@@ -15,7 +15,7 @@ Example:
 ```js
 import split from 'split' // [!code --]
 import { createInterface } from 'node:readline' // [!code ++]
-import fs from 'node:fs'
+import * as fs from 'node:fs'
 
 const input = fs.createReadStream('file.txt')
 

--- a/docs/modules/strip-ansi.md
+++ b/docs/modules/strip-ansi.md
@@ -6,7 +6,7 @@ description: Native Node.js alternatives to the strip-ansi package for removing 
 
 ## `util.stripVTControlCharacters` (native, Node.js)
 
-Added in v16.11.0, [util.stripVTControlCharacters](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) can be used to strip ANSI escape codes from a string.
+Added in v16.11.0, [`util.stripVTControlCharacters`](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) can be used to strip ANSI escape codes from a string.
 
 ```ts
 import stripAnsi from 'strip-ansi' // [!code --]

--- a/docs/modules/through.md
+++ b/docs/modules/through.md
@@ -6,7 +6,7 @@ description: Modern alternatives to the through package
 
 ## `stream.Writable` (native, Node.js)
 
-The native [`stream.Writable`](https://nodejs.org/api/stream.html#class-streamwritable) class can be used to create writable streams, which can serve the same purpose as the `through` package.
+The native [`stream.Writable`](https://nodejs.org/api/stream.html#class-streamwritable) class can be used to create writable streams. It is a suitable replacement when `through` is being used only as a sink that consumes data, rather than as a duplex/transform stream that forwards data.
 
 <!-- prettier-ignore -->
 ```ts

--- a/docs/modules/through.md
+++ b/docs/modules/through.md
@@ -6,6 +6,8 @@ description: Modern alternatives to the through package
 
 ## `stream.Writable` (native, Node.js)
 
+The native [`stream.Writable`](https://nodejs.org/api/stream.html#class-streamwritable) class can be used to create writable streams, which can serve the same purpose as the `through` package.
+
 <!-- prettier-ignore -->
 ```ts
 import through from 'through' // [!code --]

--- a/docs/modules/uuidv4.md
+++ b/docs/modules/uuidv4.md
@@ -4,7 +4,7 @@ description: Native alternatives to the uuidv4 package for UUID v4 generation
 
 # Replacements for `uuidv4`
 
-## `crypto.randomUUID` (native, browser and Node.js)
+## `crypto.randomUUID` (native)
 
 You can use [`crypto.randomUUID`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) for UUID v4 generation.
 

--- a/docs/modules/uuidv4.md
+++ b/docs/modules/uuidv4.md
@@ -4,7 +4,7 @@ description: Native alternatives to the uuidv4 package for UUID v4 generation
 
 # Replacements for `uuidv4`
 
-## `crypto.randomUUID` (native)
+## `crypto.randomUUID` (native, browser and Node.js)
 
 You can use [`crypto.randomUUID`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) for UUID v4 generation.
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This adds Node.js API docs links in various places where the native API is noted (and MDN in a few cases). Plus some minor, general improvements while I was going through the pages.

Also note in the md5 page that it is insecure and has been for a long time, with a link to the Wikipedia article.