### PR TITLE
feat: add `es6-set`, `es6-map`, and `es6-error`

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -627,6 +627,18 @@
         "compatKey": "javascript.builtins.Date.now"
       }
     },
+    "Error": {
+      "id": "Error",
+      "type": "native",
+      "url": {
+        "type": "mdn",
+        "id": "Web/JavaScript/Reference/Global_Objects/Error"
+      },
+      "webFeatureId": {
+        "featureId": "javascript",
+        "compatKey": "javascript.builtins.Error"
+      }
+    },
     "Error.isError": {
       "id": "Error.isError",
       "type": "native",
@@ -2037,10 +2049,25 @@
       "moduleName": "es5-shim",
       "replacements": ["es5-shim"]
     },
+    "es6-error": {
+      "type": "module",
+      "moduleName": "es6-error",
+      "replacements": ["Error"]
+    },
+    "es6-map": {
+      "type": "module",
+      "moduleName": "es6-map",
+      "replacements": ["Map"]
+    },
     "es6-promise": {
       "type": "module",
       "moduleName": "es6-promise",
       "replacements": ["Promise"]
+    },
+    "es6-set": {
+      "type": "module",
+      "moduleName": "es6-set",
+      "replacements": ["Set"]
     },
     "es6-shim": {
       "type": "module",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this pr adds the accepted native-replacement mappings for `es6-set`, `es6-map`, and `es6-error`, pointing them to `Set`, `Map`, and `Error` respectively, and includes a new Error native replacement entry so es6-error can reference a valid replacement in the manifest

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->

closes: #633 #634 #635
