### PR TITLE
feat(native): map `is-arrayish` to `Array.isArray`

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2217,6 +2217,11 @@
       "moduleName": "indexof",
       "replacements": ["Array.prototype.indexOf"]
     },
+    "is-arrayish": {
+      "type": "module",
+      "moduleName": "is-arrayish",
+      "replacements": ["Array.isArray"]
+    },
     "is-buffer": {
       "type": "module",
       "moduleName": "is-buffer",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this adds `is-arrayish` to the native manifest pointing at `Array.isArray`
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
closes: #622 