### PR TITLE
feat(preferred): add `bcrypt` replacements and docs

### DIFF
--- a/docs/modules/bcrypt.md
+++ b/docs/modules/bcrypt.md
@@ -1,0 +1,39 @@
+---
+description: Modern alternatives to the bcrypt package for password hashing
+---
+
+# Replacements for `bcrypt`
+
+The native `bcrypt` package is a Node addon. Depending on your constraints, you may prefer a pure JavaScript implementation, or move to built-in cryptographic primitives.
+
+## `bcryptjs`
+
+[`bcryptjs`](https://github.com/dcodeIO/bcrypt.js) is a widely used pure JavaScript implementation with a very similar API surface to `bcrypt`.
+
+```ts
+import bcrypt from 'bcrypt' // [!code --]
+import bcrypt from 'bcryptjs' // [!code ++]
+
+const salt = await bcrypt.genSalt(10) // [!code --]
+const salt = await bcrypt.genSalt(10) // [!code ++]
+
+const hash = await bcrypt.hash('password', salt) // [!code --]
+const hash = await bcrypt.hash('password', salt) // [!code ++]
+```
+
+## `node:crypto` (native, Node.js built-in)
+
+Node provides [`node:crypto`](https://nodejs.org/api/crypto.html) for secure password hashing primitives (for example `scrypt` and `pbkdf2`). This is not a drop-in `bcrypt` API replacement, but it is a common “remove `bcrypt`” direction when you can standardize on a different KDF.
+
+## Web Crypto API (native)
+
+The [Web Crypto API](https://developer.mozilla.org/docs/Web/API/Web_Crypto_API) provides native functionality for cryptographic operations in both web browsers and Node.
+
+> [!NOTE]
+> A few legacy algorithms are intentionally omitted for security reasons (e.g. MD5).
+
+## Bun (built-in)
+
+Bun supports the Web Crypto API natively, and also provides support for streaming hashing via [`Bun.CryptoHasher`](https://bun.sh/docs/api/hashing).
+
+As with the Web Crypto API, many legacy algorithms are intentionally omitted for security reasons (e.g. MD5).

--- a/docs/modules/bcrypt.md
+++ b/docs/modules/bcrypt.md
@@ -4,7 +4,7 @@ description: Modern alternatives to the bcrypt package for password hashing
 
 # Replacements for `bcrypt`
 
-The native `bcrypt` package is a Node addon. Depending on your constraints, you may prefer a pure JavaScript implementation, or move to built-in cryptographic primitives.
+The `bcrypt` package can be replaced by native functionality in most runtimes, or more performant packages.
 
 ## `bcryptjs`
 
@@ -14,16 +14,14 @@ The native `bcrypt` package is a Node addon. Depending on your constraints, you 
 import bcrypt from 'bcrypt' // [!code --]
 import bcrypt from 'bcryptjs' // [!code ++]
 
-const salt = await bcrypt.genSalt(10) // [!code --]
-const salt = await bcrypt.genSalt(10) // [!code ++]
+const salt = await bcrypt.genSalt(10)
 
-const hash = await bcrypt.hash('password', salt) // [!code --]
-const hash = await bcrypt.hash('password', salt) // [!code ++]
+const hash = await bcrypt.hash('password', salt)
 ```
 
 ## `node:crypto` (native, Node.js built-in)
 
-Node provides [`node:crypto`](https://nodejs.org/api/crypto.html) for secure password hashing primitives (for example `scrypt` and `pbkdf2`). This is not a drop-in `bcrypt` API replacement, but it is a common “remove `bcrypt`” direction when you can standardize on a different KDF.
+Node provides [`node:crypto`](https://nodejs.org/api/crypto.html) for secure password hashing primitives (for example `scrypt` and `pbkdf2`). This is not a drop-in `bcrypt` API replacement, but is a good option if you can switch to a more secure cryptographic algorithm it supports.
 
 ## Web Crypto API (native)
 

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -48,6 +48,12 @@
       "replacements": ["fetch", "ofetch", "ky"],
       "url": {"type": "e18e", "id": "fetch"}
     },
+    "bcrypt": {
+      "type": "module",
+      "moduleName": "bcrypt",
+      "replacements": ["bcryptjs", "node:crypto", "crypto", "Bun.CryptoHasher"],
+      "url": {"type": "e18e", "id": "bcrypt"}
+    },
     "bluebird": {
       "type": "module",
       "moduleName": "bluebird",
@@ -2904,6 +2910,11 @@
       "id": "ansis",
       "type": "documented",
       "replacementModule": "ansis"
+    },
+    "bcryptjs": {
+      "id": "bcryptjs",
+      "type": "documented",
+      "replacementModule": "bcryptjs"
     },
     "betterknown": {
       "id": "betterknown",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
adds `bcrypt` to the preferred manifest with `bcryptjs` as the primary replacement and follows the same broader crypto fallback story used for `crypto-js` (`node:crypto`, `crypto`, `Bun.CryptoHasher`), plus a new page that explains when to use `bcryptjs` 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
closes: #625 