### PR TITLE
feat(preferred): Add `oxlint` as an alternative for `eslint-plugin-import` and `eslint-plugin-react`

### DIFF
--- a/docs/modules/eslint-plugin-import.md
+++ b/docs/modules/eslint-plugin-import.md
@@ -72,6 +72,7 @@ Oxlint is intended to be backwards-compatible with ESLint as much as possible, b
 The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) and can usually be done automatically from an ESLint flat config using [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
 
 > [!NOTE]
+
 ## Oxlint
 
 [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) is a high-performance linter for JavaScript and TypeScript, built on the Rust-based `Oxc` compiler stack. It's intended to be fully backwards-compatible with ESLint, having ported most of the ESLint rules, as well as those from popular plugins including `eslint-plugin-import`.

--- a/docs/modules/eslint-plugin-import.md
+++ b/docs/modules/eslint-plugin-import.md
@@ -63,16 +63,6 @@ module.exports = {
 }
 ```
 
-## `oxlint`
-
-[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint. It has ports of most rules from ESLint and its popular plugins, including `eslint-plugin-import`.
-
-Oxlint is intended to be backwards-compatible with ESLint as much as possible, but not all rules are implemented yet, and some are not planned to be implemented at all. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1117) for specifics.
-
-The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) and can usually be done automatically from an ESLint flat config using [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
-
-> [!NOTE]
-
 ## Oxlint
 
 [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) is a high-performance linter for JavaScript and TypeScript, built on the Rust-based `Oxc` compiler stack. It's intended to be fully backwards-compatible with ESLint, having ported most of the ESLint rules, as well as those from popular plugins including `eslint-plugin-import`.

--- a/docs/modules/eslint-plugin-import.md
+++ b/docs/modules/eslint-plugin-import.md
@@ -65,7 +65,7 @@ module.exports = {
 
 ## `oxlint`
 
-[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint, It has most of the rules from ESLint and its popular plugins ported, including `eslint-plugin-import`.
+[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint. It has ports of most rules from ESLint and its popular plugins, including `eslint-plugin-import`.
 
 Oxlint is intended to be backwards-compatible with ESLint as much as possible, but not all rules are implemented yet, and some are not planned to be implemented at all. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1117) for specifics.
 

--- a/docs/modules/eslint-plugin-import.md
+++ b/docs/modules/eslint-plugin-import.md
@@ -62,3 +62,14 @@ module.exports = {
   }
 }
 ```
+
+## `oxlint`
+
+[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint, It has most of the rules from ESLint and its popular plugins ported, including `eslint-plugin-import`.
+
+Oxlint is intended to be backwards-compatible with ESLint as much as possible, but not all rules are implemented yet, and some are not planned to be implemented at all. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1117) for specifics.
+
+The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) and can usually be done automatically from an ESLint flat config using [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
+
+> [!NOTE]
+> `oxlint` is not necessarily a full, drop‑in replacement. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1117) for rules from `eslint-plugin-import` that are not yet implemented or not planned to be implemented.

--- a/docs/modules/eslint-plugin-import.md
+++ b/docs/modules/eslint-plugin-import.md
@@ -72,4 +72,4 @@ Oxlint is intended to be backwards-compatible with ESLint as much as possible, b
 The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) and can usually be done automatically from an ESLint flat config using [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
 
 > [!NOTE]
-> `oxlint` is not necessarily a full, drop‑in replacement. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1117) for rules from `eslint-plugin-import` that are not yet implemented or not planned to be implemented.
+> `oxlint` is not necessarily a full, drop-in replacement. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1117) for rules from `eslint-plugin-import` that are not yet implemented or not planned to be implemented.

--- a/docs/modules/eslint-plugin-import.md
+++ b/docs/modules/eslint-plugin-import.md
@@ -72,4 +72,11 @@ Oxlint is intended to be backwards-compatible with ESLint as much as possible, b
 The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) and can usually be done automatically from an ESLint flat config using [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
 
 > [!NOTE]
-> `oxlint` is not necessarily a full, drop-in replacement. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1117) for rules from `eslint-plugin-import` that are not yet implemented or not planned to be implemented.
+## Oxlint
+
+[Oxlint](https://oxc.rs/docs/guide/usage/linter.html) is a high-performance linter for JavaScript and TypeScript, built on the Rust-based `Oxc` compiler stack. It's intended to be fully backwards-compatible with ESLint, having ported most of the ESLint rules, as well as those from popular plugins including `eslint-plugin-import`.
+
+The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html), and can be done automatically from an ESLint flat config using [`npx @oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
+
+> [!NOTE]
+> Oxlint is not necessarily a full drop-in replacement, as not all of the `eslint-plugin-import` rules have been, or will be, implemented. Check [the GitHub issue](https://github.com/oxc-project/oxc/issues/1117) to view the progress.

--- a/docs/modules/eslint-plugin-react.md
+++ b/docs/modules/eslint-plugin-react.md
@@ -37,11 +37,11 @@ export default [
 
 ## `oxlint`
 
-[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint, It has most of the rules from ESLint and its popular plugins ported, including `eslint-plugin-react` (as well as a few `eslint-plugin-react-hooks` rules).
+[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint. It has most of the rules from ESLint and its popular plugins ported, including `eslint-plugin-react` (as well as a few `eslint-plugin-react-hooks` rules).
 
 Oxlint is intended to be backwards-compatible with ESLint as much as possible, but not all rules are implemented yet, and some are not planned to be implemented at all. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1022) for specifics.
 
-[JS Plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins.html) are supported, and compatible with ESLint plugins if there are other ESLint plugins needing to be migrated. JS Plugins can also be used to migrate React Compiler rules over to Oxlint if needed.
+[JS Plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins.html) are supported and are compatible with ESLint plugins if there are other ESLint plugins needing to be migrated. JS Plugins can also be used to migrate React Compiler rules over to Oxlint if needed.
 
 The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) and can usually be done automatically from an ESLint flat config using [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
 

--- a/docs/modules/eslint-plugin-react.md
+++ b/docs/modules/eslint-plugin-react.md
@@ -35,15 +35,11 @@ export default [
 > [!NOTE]
 > `@eslint-react/eslint-plugin` is not a drop‑in replacement. Use [their migration guide](https://www.eslint-react.xyz/docs/migrating-from-eslint-plugin-react) to map rules/options and automate changes where possible.
 
-## `oxlint`
+## Oxlint
 
-[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint. It has ports of most rules from ESLint and its popular plugins, including `eslint-plugin-react` (as well as a few `eslint-plugin-react-hooks` rules).
+[Oxlint](https://oxc.rs/docs/guide/usage/linter.html) is a high-performance linter for JavaScript and TypeScript, built on the Rust-based `Oxc` compiler stack. It's intended to be fully backwards-compatible with ESLint, having ported most of the ESLint rules, as well as those from popular plugins including `eslint-plugin-react`.
 
-Oxlint is intended to be backwards-compatible with ESLint as much as possible, but not all rules are implemented yet, and some are not planned to be implemented at all. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1022) for specifics.
-
-[JS Plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins.html) are supported and are compatible with ESLint plugins if there are other ESLint plugins needing to be migrated. JS Plugins can also be used to migrate React Compiler rules over to Oxlint if needed.
-
-The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) and can usually be done automatically from an ESLint flat config using [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
+The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html), and can be done automatically from an ESLint flat config using [`npx @oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
 
 > [!NOTE]
-> `oxlint` is not necessarily a full, drop-in replacement. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1022) for rules from `eslint-plugin-react` that are not yet implemented or not planned to be implemented.
+> Oxlint is not necessarily a full drop-in replacement, as not all of the `eslint-plugin-react` rules have been, or will be, implemented. Check [the GitHub issue](https://github.com/oxc-project/oxc/issues/1022) to view the progress.

--- a/docs/modules/eslint-plugin-react.md
+++ b/docs/modules/eslint-plugin-react.md
@@ -37,7 +37,7 @@ export default [
 
 ## `oxlint`
 
-[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint. It has most of the rules from ESLint and its popular plugins ported, including `eslint-plugin-react` (as well as a few `eslint-plugin-react-hooks` rules).
+[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint. It has ports of most rules from ESLint and its popular plugins, including `eslint-plugin-react` (as well as a few `eslint-plugin-react-hooks` rules).
 
 Oxlint is intended to be backwards-compatible with ESLint as much as possible, but not all rules are implemented yet, and some are not planned to be implemented at all. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1022) for specifics.
 

--- a/docs/modules/eslint-plugin-react.md
+++ b/docs/modules/eslint-plugin-react.md
@@ -34,3 +34,16 @@ export default [
 
 > [!NOTE]
 > `@eslint-react/eslint-plugin` is not a drop‑in replacement. Use [their migration guide](https://www.eslint-react.xyz/docs/migrating-from-eslint-plugin-react) to map rules/options and automate changes where possible.
+
+## `oxlint`
+
+[`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter for JavaScript and TypeScript that is compatible with ESLint, It has most of the rules from ESLint and its popular plugins ported, including `eslint-plugin-react` (as well as a few `eslint-plugin-react-hooks` rules).
+
+Oxlint is intended to be backwards-compatible with ESLint as much as possible, but not all rules are implemented yet, and some are not planned to be implemented at all. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1022) for specifics.
+
+[JS Plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins.html) are supported, and compatible with ESLint plugins if there are other ESLint plugins needing to be migrated. JS Plugins can also be used to migrate React Compiler rules over to Oxlint if needed.
+
+The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) and can usually be done automatically from an ESLint flat config using [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
+
+> [!NOTE]
+> `oxlint` is not necessarily a full, drop‑in replacement. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1022) for rules from `eslint-plugin-react` that are not yet implemented or not planned to be implemented.

--- a/docs/modules/eslint-plugin-react.md
+++ b/docs/modules/eslint-plugin-react.md
@@ -46,4 +46,4 @@ Oxlint is intended to be backwards-compatible with ESLint as much as possible, b
 The migration process from ESLint is covered in [the Oxlint documentation](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) and can usually be done automatically from an ESLint flat config using [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate).
 
 > [!NOTE]
-> `oxlint` is not necessarily a full, drop‑in replacement. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1022) for rules from `eslint-plugin-react` that are not yet implemented or not planned to be implemented.
+> `oxlint` is not necessarily a full, drop-in replacement. See [the GitHub issue](https://github.com/oxc-project/oxc/issues/1022) for rules from `eslint-plugin-react` that are not yet implemented or not planned to be implemented.

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -267,7 +267,7 @@
     "eslint-plugin-import": {
       "type": "module",
       "moduleName": "eslint-plugin-import",
-      "replacements": ["eslint-plugin-import-x"],
+      "replacements": ["eslint-plugin-import-x", "oxlint"],
       "url": {"type": "e18e", "id": "eslint-plugin-import"}
     },
     "eslint-plugin-node": {
@@ -279,7 +279,7 @@
     "eslint-plugin-react": {
       "type": "module",
       "moduleName": "eslint-plugin-react",
-      "replacements": ["@eslint-react/eslint-plugin"],
+      "replacements": ["@eslint-react/eslint-plugin", "oxlint"],
       "url": {"type": "e18e", "id": "eslint-plugin-react"}
     },
     "eslint-plugin-vitest": {

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -3323,6 +3323,11 @@
       "type": "documented",
       "replacementModule": "oxc-resolver"
     },
+    "oxlint": {
+      "id": "oxlint",
+      "type": "documented",
+      "replacementModule": "oxlint"
+    },
     "package-manager-detector": {
       "id": "package-manager-detector",
       "type": "documented",


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #663.

### 📚 Description

Suggest [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) as an alternative to these two plugins, as both plugins' rules are supported natively (though only a large majority of the rules, not all of the rules).

I added the disclaimer about Oxlint not being a full drop-in replacement to match the disclaimer on the `eslint-plugin-react` page about the `@eslint-react/eslint-plugin` package. The disclaimer is a bit repetitive since it's basically mentioned twice in each of these pages (again, to match how the`@eslint-react/eslint-plugin` package section was written), I can simplify it to just the NOTE section if preferred.

I've also added `oxlint` in the preferred JSON file for these two packages. I can add this to `eslint-plugin-vitest` as well, but it feels like a different kind of replacement given that the current entry is only technically about a package rename (`eslint-plugin-vitest` to `@vitest/eslint-plugin`). I think it's not a good idea to add for eslint-plugin-node right now, as only a small portion of the rules from that plugin have been ported to Oxlint so far.

`eslint-plugin-import` currently has **123** total deps and subdeps. So I think it's definitely worth suggesting alternatives.

You can see the Oxlint rules list here: https://oxc.rs/docs/guide/usage/linter/rules.html

And issues for tracking the rule porting process on each plugin here: https://github.com/oxc-project/oxc/issues/481