### PR TITLE
feat: export `dist/util.js` separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,12 @@
         "default": "./dist/main.js"
       }
     },
+    "./util": {
+      "import": {
+        "types": "./dist/util.d.ts",
+        "default": "./dist/util.js"
+      }
+    },
     "./manifests/*.json": "./manifests/*.json",
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "default": "./dist/main.js"
       }
     },
-    "./util": {
+    "./dist/util": {
       "import": {
         "types": "./dist/util.d.ts",
         "default": "./dist/util.js"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "default": "./dist/main.js"
       }
     },
-    "./dist/util": {
+    "./dist/util.js": {
       "import": {
         "types": "./dist/util.d.ts",
         "default": "./dist/util.js"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Add `./util` in `exports` field to allow importing `resolveDocUrl` via the `./util` subpath, so consumers don't need to pull in the full manifest when they only need the utility.

Feel free to close if this doesn't align with the project's direction.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
