### PR TITLE
feat(preferred): Add eslint-config-airbnb-extended to preferred.json, add docs page.

### DIFF
--- a/docs/modules/eslint-config-airbnb.md
+++ b/docs/modules/eslint-config-airbnb.md
@@ -1,0 +1,15 @@
+---
+description: Modern, maintained alternative to the eslint-config-airbnb shared config
+---
+
+# Replacements for `eslint-config-airbnb`
+
+## `eslint-config-airbnb-extended`
+
+[`eslint-config-airbnb-extended`](https://github.com/eslint-config/airbnb-extended) is a more modern, actively maintained successor to [`eslint-config-airbnb`](https://github.com/airbnb/javascript). It supports both JavaScript and TypeScript, and includes rules for React, JSX, and React Hooks, and supports ESLint v9/10 configs.
+
+It consolidates `eslint-config-airbnb-base`, `eslint-config-airbnb`, and `eslint-config-airbnb-typescript` into a single config, only supports flat config (`eslint.config.mjs`), and uses a faster, modern equivalent of the `import` plugin (`eslint-plugin-import-x`).
+
+The upstream project provides an official [migration guide](https://eslint-airbnb-extended.nishargshah.dev/migration/upgrade-to-extended) and a CLI scaffolder to set up a new config.
+
+Note that any rules referencing the old `import/*` plugin will need to be updated to use the `import-x/*` equivalents (e.g. `import/no-unresolved` -> `import-x/no-unresolved`).

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -252,6 +252,12 @@
       "replacements": ["emoji-regex-xs", "unicodeClassEscape"],
       "url": {"type": "e18e", "id": "emoji-regex"}
     },
+    "eslint-config-airbnb": {
+      "type": "module",
+      "moduleName": "eslint-config-airbnb",
+      "replacements": ["eslint-config-airbnb-extended"],
+      "url": {"type": "e18e", "id": "eslint-config-airbnb"}
+    },
     "eslint-plugin-es": {
       "type": "module",
       "moduleName": "eslint-plugin-es",
@@ -3048,6 +3054,11 @@
       "id": "es-toolkit",
       "type": "documented",
       "replacementModule": "es-toolkit"
+    },
+    "eslint-config-airbnb-extended": {
+      "id": "eslint-config-airbnb-extended",
+      "type": "documented",
+      "replacementModule": "eslint-config-airbnb-extended"
     },
     "eslint-plugin-es-x": {
       "id": "eslint-plugin-es-x",


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #660

### 📚 Description

Just basic coverage/docs for the eslint-config-airbnb replacement module.

Original: https://github.com/airbnb/javascript

Replacement: https://github.com/eslint-config/airbnb-extended

The goal here is to point people from an older, mostly-unmaintained ESLint config toward one that is maintained and supports faster alternative plugins (import -> import-x). Relatively straight-forward.