### PR TITLE
feat: add `universal-deep-strict-equal` to preferred manifest

### DIFF
--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2596,7 +2596,7 @@
     },
     "universal-deep-strict-equal": {
       "type": "module",
-      "moduleName": "deep-equal",
+      "moduleName": "universal-deep-strict-equal",
       "replacements": ["dequal", "util.isDeepStrictEqual", "Bun.deepEquals"],
       "url": {"type": "e18e", "id": "deep-equal"}
     },

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2594,6 +2594,12 @@
       "replacements": ["lodash-underscore", "es-toolkit"],
       "url": {"type": "e18e", "id": "lodash-underscore"}
     },
+    "universal-deep-strict-equal": {
+      "type": "module",
+      "moduleName": "deep-equal",
+      "replacements": ["dequal", "util.isDeepStrictEqual", "Bun.deepEquals"],
+      "url": {"type": "e18e", "id": "deep-equal"}
+    },
     "uri-js": {
       "type": "module",
       "moduleName": "uri-js",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #608

### 📚 Description

Adds `universal-deep-strict-equal` to preferred manifest
