### PR TITLE
feat: add `duplexer3` and `duplexify` to preferred manifest

### DIFF
--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -237,13 +237,25 @@
     "duplexer": {
       "type": "module",
       "moduleName": "duplexer",
-      "replacements": ["node:stream"],
+      "replacements": ["stream.Duplex"],
       "url": {"type": "e18e", "id": "duplexer"}
     },
     "duplexer2": {
       "type": "module",
       "moduleName": "duplexer2",
-      "replacements": ["node:stream"],
+      "replacements": ["stream.Duplex"],
+      "url": {"type": "e18e", "id": "duplexer"}
+    },
+    "duplexer3": {
+      "type": "module",
+      "moduleName": "duplexer3",
+      "replacements": ["stream.Duplex"],
+      "url": {"type": "e18e", "id": "duplexer"}
+    },
+    "duplexify": {
+      "type": "module",
+      "moduleName": "duplexify",
+      "replacements": ["stream.Duplex"],
       "url": {"type": "e18e", "id": "duplexer"}
     },
     "emoji-regex": {
@@ -3326,6 +3338,12 @@
       "id": "sortobject",
       "type": "documented",
       "replacementModule": "sortobject"
+    },
+    "stream.Duplex": {
+      "id": "stream.Duplex",
+      "type": "native",
+      "url": {"type": "node", "id": "api/stream.html#class-streamduplex"},
+      "nodeFeatureId": {"moduleName": "node:stream", "exportName": "Duplex"}
     },
     "streams": {
       "id": "streams",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #679
Closes #680

### 📚 Description

Adds `duplexer3` and `duplexify` to preferred manifest
