### PR TITLE
docs: add `Bun.deepEquals` to deep-equal replacements page

### DIFF
--- a/docs/modules/deep-equal.md
+++ b/docs/modules/deep-equal.md
@@ -21,6 +21,23 @@ equal(a, b) // true [!code --]
 isDeepStrictEqual(a, b) // true [!code ++]
 ```
 
+## `dequal`
+
+[`dequal`](https://github.com/lukeed/dequal) has the same simple API as `deep-equal`.
+
+Example:
+
+```ts
+import equal from 'deep-equal' // [!code --]
+import dequal from 'dequal' // [!code ++]
+
+const a = { foo: 'bar' }
+const b = { foo: 'bar' }
+
+equal(a, b) // true [!code --]
+dequal(a, b) // true [!code ++]
+```
+
 ## `Bun.deepEquals` (native, Bun)
 
 Bun exposes [`Bun.deepEquals`](https://bun.com/docs/runtime/utils#bun-deepequals) globally on the Bun runtime. It accepts two values to compare and an optional `strict` flag (default `false`).
@@ -41,21 +58,4 @@ For behavior equivalent to `deep-equal`'s strict mode, pass `true` as the third 
 
 ```ts
 Bun.deepEquals(a, b, true)
-```
-
-## `dequal`
-
-[`dequal`](https://github.com/lukeed/dequal) has the same simple API as `deep-equal`.
-
-Example:
-
-```ts
-import equal from 'deep-equal' // [!code --]
-import dequal from 'dequal' // [!code ++]
-
-const a = { foo: 'bar' }
-const b = { foo: 'bar' }
-
-equal(a, b) // true [!code --]
-dequal(a, b) // true [!code ++]
 ```

--- a/docs/modules/deep-equal.md
+++ b/docs/modules/deep-equal.md
@@ -21,6 +21,28 @@ equal(a, b) // true [!code --]
 isDeepStrictEqual(a, b) // true [!code ++]
 ```
 
+## `Bun.deepEquals` (native, Bun)
+
+Bun exposes [`Bun.deepEquals`](https://bun.com/docs/runtime/utils#bun-deepequals) globally on the Bun runtime. It accepts two values to compare and an optional `strict` flag (default `false`).
+
+Example:
+
+```ts
+import equal from 'deep-equal' // [!code --]
+
+const a = { foo: 'bar' }
+const b = { foo: 'bar' }
+
+equal(a, b) // true [!code --]
+Bun.deepEquals(a, b) // true [!code ++]
+```
+
+For behavior equivalent to `deep-equal`'s strict mode, pass `true` as the third argument:
+
+```ts
+Bun.deepEquals(a, b, true)
+```
+
 ## `dequal`
 
 [`dequal`](https://github.com/lukeed/dequal) has the same simple API as `deep-equal`.

--- a/docs/modules/deep-equal.md
+++ b/docs/modules/deep-equal.md
@@ -40,7 +40,7 @@ dequal(a, b) // true [!code ++]
 
 ## `Bun.deepEquals` (native, Bun)
 
-Bun exposes [`Bun.deepEquals`](https://bun.com/docs/runtime/utils#bun-deepequals) globally on the Bun runtime. It accepts two values to compare and an optional `strict` flag (default `false`).
+Bun has a built-in [`Bun.deepEquals`](https://bun.com/docs/runtime/utils#bun-deepequals) function. It accepts two values to compare, and an optional `strict` flag (default `false`).
 
 Example:
 
@@ -52,10 +52,8 @@ const b = { foo: 'bar' }
 
 equal(a, b) // true [!code --]
 Bun.deepEquals(a, b) // true [!code ++]
-```
 
-For behavior equivalent to `deep-equal`'s strict mode, pass `true` as the third argument:
-
-```ts
-Bun.deepEquals(a, b, true)
+// Strict Mode
+equal(a, b, { strict: true }) // true [!code --]
+Bun.deepEquals(a, b, true) // true [!code ++]
 ```


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #698.

### 📚 Description

The `deep-equal` doc page lists `util.isDeepStrictEqual` and `dequal` but not `Bun.deepEquals`, even though all four mappings that point at this doc (`deep-equal`, `deep-equal-json`, `lodash.isequal`, `universal-deep-strict-equal`) already list `Bun.deepEquals` as a replacement in `manifests/preferred.json`.

Added a `## Bun.deepEquals` section following the style of the existing native section. It documents the loose default and notes the opt-in `strict` flag, since `deep-equal` itself ships both modes and a migrating user may need the strict variant.

`pnpm lint` is clean.