### PR TITLE
fix: first node version that supports `fs.mkdtempDisposable`

### DIFF
--- a/docs/modules/tempy.md
+++ b/docs/modules/tempy.md
@@ -20,7 +20,7 @@ const tempDirPath = temp.mkdirSync('foo') // [!code --]
 const tempDirPath = await mkdtemp(join(await realpath(tmpdir()), 'foo-')) // [!code ++]
 ```
 
-## `fs.mkdtempDisposable` (native, since Node.js v20.4.0)
+## `fs.mkdtempDisposable` (native, since Node.js v24.4.0)
 
 Node.js now provides [`fs.mkdtempDisposable`](https://nodejs.org/api/fs.html#fspromisesmkdtempdisposableprefix-options) which leverages the `using` keyword for automatic cleanup. This eliminates the need for `temp.track()` or manual cleanup logic.
 


### PR DESCRIPTION

### 📚 Description

According to [the Node docs](https://nodejs.org/api/fs.html#fspromisesmkdtempdisposableprefix-options), `mkdtempDisposable` was added in Node 24.4.0, not 20.4.0 as we say currently.

This also tracks with the fact that Node only added support for the explicit resource managenment and the `using` keyword in version 24.


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
