### PR TITLE
feat(preferred): add tsdown as documented replacement

### DIFF
--- a/docs/modules/tsup.md
+++ b/docs/modules/tsup.md
@@ -1,0 +1,49 @@
+---
+description: Modern alternative to tsup for bundling TypeScript libraries
+---
+
+# Replacements for `tsup`
+
+## Scope
+
+This replacement is for **existing `tsup` users** only. It is not a recommendation for projects on other bundlers, or for projects that do not need a bundler.
+
+## `tsdown`
+
+[tsdown](https://github.com/rolldown/tsdown) is the successor recommended by [tsup's own README](https://github.com/egoist/tsup) since August 2025. The project is effectively in maintenance mode. tsdown is built on Rolldown and is typically faster for library builds, with a largely drop-in config surface.
+
+### Config migration
+
+Most `tsup.config.ts` files map 1:1 to `tsdown.config.ts`:
+
+```ts
+import { defineConfig } from 'tsup' // [!code --]
+import { defineConfig } from 'tsdown' // [!code ++]
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true
+})
+```
+
+### Package scripts
+
+```json
+{
+  "scripts": {
+    "build": "tsup" // [!code --]
+    "build": "tsdown" // [!code ++]
+  }
+}
+```
+
+### Automated migration
+
+- `npx tsdown-migrate`
+- `npx skills add rolldown/tsdown --skill tsdown-migrate`
+
+### Requirements
+
+- Node.js >= 20.19 (current active LTS line)

--- a/docs/modules/tsup.md
+++ b/docs/modules/tsup.md
@@ -4,10 +4,6 @@ description: Modern alternative to tsup for bundling TypeScript libraries
 
 # Replacements for `tsup`
 
-## Scope
-
-This replacement is for **existing `tsup` users** only. It is not a recommendation for projects on other bundlers, or for projects that do not need a bundler.
-
 ## `tsdown`
 
 [tsdown](https://github.com/rolldown/tsdown) is the successor recommended by [tsup's own README](https://github.com/egoist/tsup) since August 2025. The project is effectively in maintenance mode. tsdown is built on Rolldown and is typically faster for library builds, with a largely drop-in config surface.
@@ -43,7 +39,3 @@ export default defineConfig({
 
 - `npx tsdown-migrate`
 - `npx skills add rolldown/tsdown --skill tsdown-migrate`
-
-### Requirements
-
-- Node.js >= 20.19 (current active LTS line)

--- a/docs/modules/tsup.md
+++ b/docs/modules/tsup.md
@@ -6,7 +6,7 @@ description: Modern alternative to tsup for bundling TypeScript libraries
 
 ## `tsdown`
 
-[tsdown](https://github.com/rolldown/tsdown) is the successor recommended by [tsup's own README](https://github.com/egoist/tsup) since August 2025. The project is effectively in maintenance mode. tsdown is built on Rolldown and is typically faster for library builds, with a largely drop-in config surface.
+[tsdown](https://github.com/rolldown/tsdown) is the successor recommended by [tsup's own README](https://github.com/egoist/tsup). The project is effectively in maintenance mode. tsdown is built on Rolldown and is typically faster for library builds, with a largely drop-in config surface.
 
 ### Config migration
 

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2600,6 +2600,12 @@
       "replacements": ["neotraverse"],
       "url": {"type": "e18e", "id": "traverse"}
     },
+    "tsup": {
+      "type": "module",
+      "moduleName": "tsup",
+      "replacements": ["tsdown"],
+      "url": {"type": "e18e", "id": "tsup"}
+    },
     "uid-safe": {
       "type": "module",
       "moduleName": "uid-safe",
@@ -3405,6 +3411,11 @@
       "id": "ts-graphviz",
       "type": "documented",
       "replacementModule": "ts-graphviz"
+    },
+    "tsdown": {
+      "id": "tsdown",
+      "type": "documented",
+      "replacementModule": "tsdown"
     },
     "unicode-segmenter": {
       "id": "unicode-segmenter",


### PR DESCRIPTION
### 🔗 Linked issue

closes: #649

### 📚 Description

 adds `tsup` → `tsdown` as a `documented` replacement in the `preferred` manifest and migration docs with scope note