### PR TITLE
feat(preferred): add mississippi to replacements

### DIFF
--- a/docs/modules/mississippi.md
+++ b/docs/modules/mississippi.md
@@ -58,7 +58,6 @@ import miss from 'mississippi' // [!code --]
 import { Duplex } from 'node:stream' // [!code ++]
  
 miss.duplex(writableStream, readableStream) // [!code --]
- 
 Duplex.from({ // [!code ++]
   writable: writableStream, // [!code ++]
   readable: readableStream // [!code ++]
@@ -79,7 +78,6 @@ import { Transform } from 'node:stream' // [!code ++]
 miss.through((chunk, enc, cb) => { // [!code --]
   cb(null, fn(chunk)) // [!code --]
 }) // [!code --]
- 
 new Transform({ // [!code ++]
   transform(chunk, encoding, callback) { // [!code ++]
     callback(null, fn(chunk)) // [!code ++]
@@ -124,7 +122,6 @@ import miss from 'mississippi' // [!code --]
 import { Readable } from 'node:stream' // [!code ++]
  
 miss.from((size, cb) => cb(null, chunk)) // [!code --]
- 
 Readable.from( // [!code ++]
   (async function* () { // [!code ++]
     yield chunk // [!code ++]
@@ -143,7 +140,6 @@ miss.to( // [!code --]
   (chunk, enc, cb) => cb(), // [!code --]
   (cb) => cb() // [!code --]
 ) // [!code --]
- 
 new Writable({ // [!code ++]
   write(chunk, encoding, callback) { // [!code ++]
     callback() // [!code ++]
@@ -163,7 +159,6 @@ import miss from 'mississippi' // [!code --]
 stream.pipe( // [!code --]
   miss.parallel(10, (data, cb) => cb(null, fn(data))) // [!code --]
 ) // [!code --]
- 
 stream.map((data) => fn(data), { concurrency: 10 }) // [!code ++]
 ```
 

--- a/docs/modules/mississippi.md
+++ b/docs/modules/mississippi.md
@@ -1,29 +1,29 @@
 ---
 description: Modern alternatives to the mississippi package
 ---
- 
+
 # Replacements for `mississippi`
- 
+
 `mississippi` is a facade that re-exports existing stream packages. Replace each export with the corresponding native `node:stream` API (or import the underlying package directly if you still need it).
- 
+
 ## `ms.pipe()` replacement
- 
+
 Replaces `pump`.
- 
+
 ```ts
 import miss from 'mississippi' // [!code --]
 import { pipeline } from 'node:stream/promises' // [!code ++]
- 
+
 miss.pipe(s1, s2, s3, cb) // [!code --]
 await pipeline(s1, s2, s3) // [!code ++]
 ```
- 
+
 For callback-style usage, use [`stream.pipeline`](https://nodejs.org/api/stream.html#streampipelinestreams-callback).
- 
+
 ## `ms.each()` replacement
- 
+
 Replaces `stream-each`.
- 
+
 <!-- prettier-ignore -->
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -37,27 +37,27 @@ for await (const data of stream) { // [!code ++]
   fn(data) // [!code ++]
 } // [!code ++]
 ```
- 
+
 Note that `stream-each` reports stream errors through its done callback, while `for await` throws them — wrap the loop in `try/catch` to handle errors.
- 
+
 ## `ms.pipeline()` replacement
- 
+
 Replaces `pumpify`.
- 
+
 ```ts
 import miss from 'mississippi' // [!code --]
 import { compose } from 'node:stream' // [!code ++]
- 
+
 miss.pipeline(s1, s2, s3) // [!code --]
 compose(s1, s2, s3) // [!code ++]
 ```
- 
+
 Requires Node.js ≥ 16.9.0.
- 
+
 ## `ms.duplex()` replacement
- 
+
 Replaces `duplexify`. See also [duplexer replacements](./duplexer.md).
- 
+
 <!-- prettier-ignore -->
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -70,13 +70,13 @@ Duplex.from({ // [!code ++]
   readable: readableStream // [!code ++]
 }) // [!code ++]
 ```
- 
+
 Requires Node.js ≥ 16.8.0 for `Duplex.from`.
- 
+
 ## `ms.through()` replacement
- 
+
 Replaces `through2`. See also [through replacements](./through.md).
- 
+
 <!-- prettier-ignore -->
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -92,42 +92,42 @@ new Transform({ // [!code ++]
   } // [!code ++]
 }) // [!code ++]
 ```
- 
+
 ## `ms.concat()` replacement
- 
+
 Replaces `concat-stream`. See also [get-stream replacements](./get-stream.md).
- 
+
 ```ts
 import miss from 'mississippi' // [!code --]
 import { buffer } from 'node:stream/consumers' // [!code ++]
- 
+
 stream.pipe(miss.concat((data) => fn(data))) // [!code --]
 const data = await buffer(stream) // [!code ++]
 fn(data) // [!code ++]
 ```
- 
+
 Unlike `concat-stream`, which adapts its output to the input type, `buffer` always returns a `Buffer`. `node:stream/consumers` also exports `text`, `json`, and `arrayBuffer` for those cases.
- 
+
 Requires Node.js ≥ 16.7.0 for `node:stream/consumers`.
- 
+
 ## `ms.finished()` replacement
- 
+
 Replaces `end-of-stream`.
- 
+
 ```ts
 import miss from 'mississippi' // [!code --]
 import { finished } from 'node:stream/promises' // [!code ++]
- 
+
 miss.finished(stream, cb) // [!code --]
 await finished(stream) // [!code ++]
 ```
- 
+
 For callback-style usage, use [`stream.finished`](https://nodejs.org/api/stream.html#streamfinishedstream-options-callback).
- 
+
 ## `ms.from()` replacement
- 
+
 Replaces `from2`.
- 
+
 <!-- prettier-ignore -->
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -141,11 +141,11 @@ Readable.from( // [!code ++]
   })() // [!code ++]
 ) // [!code ++]
 ```
- 
+
 ## `ms.to()` replacement
- 
+
 Replaces `flush-write-stream`.
- 
+
 <!-- prettier-ignore -->
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -165,11 +165,11 @@ new Writable({ // [!code ++]
   } // [!code ++]
 }) // [!code ++]
 ```
- 
+
 ## `ms.parallel()` replacement
- 
+
 Replaces `parallel-transform`.
- 
+
 <!-- prettier-ignore -->
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -180,7 +180,7 @@ stream.pipe( // [!code --]
  
 stream.map((data) => fn(data), { concurrency: 10 }) // [!code ++]
 ```
- 
+
 Like `parallel-transform`, `map` preserves the order of the input stream.
- 
+
 Requires Node.js ≥ 17.4.0 for `Readable.prototype.map`.

--- a/docs/modules/mississippi.md
+++ b/docs/modules/mississippi.md
@@ -4,11 +4,9 @@ description: Modern alternatives to the mississippi package
 
 # Replacements for `mississippi`
 
-`mississippi` is a facade that re-exports existing stream packages. Replace each export with the corresponding native `node:stream` API (or import the underlying package directly if you still need it).
+`mississippi` exposes stream helpers as `miss.pipe`, `miss.each`, `miss.pipeline`, and so on. Each export wraps a separate npm package internally, but migration targets the **`miss.*` call sites** and replaces each with the corresponding native `node:stream` API below.
 
-## `ms.pipe()` replacement
-
-Replaces `pump`.
+## `miss.pipe`
 
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -20,9 +18,7 @@ await pipeline(s1, s2, s3) // [!code ++]
 
 For callback-style usage, use [`stream.pipeline`](https://nodejs.org/api/stream.html#streampipelinestreams-callback).
 
-## `ms.each()` replacement
-
-Replaces `stream-each`.
+## `miss.each`
 
 <!-- prettier-ignore -->
 ```ts
@@ -38,11 +34,9 @@ for await (const data of stream) { // [!code ++]
 } // [!code ++]
 ```
 
-Note that `stream-each` reports stream errors through its done callback, while `for await` throws them — wrap the loop in `try/catch` to handle errors.
+Note that `miss.each` reports stream errors through its done callback, while `for await` throws them wrap the loop in `try/catch` to handle errors.
 
-## `ms.pipeline()` replacement
-
-Replaces `pumpify`.
+## `miss.pipeline`
 
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -54,9 +48,9 @@ compose(s1, s2, s3) // [!code ++]
 
 Requires Node.js ≥ 16.9.0.
 
-## `ms.duplex()` replacement
+## `miss.duplex`
 
-Replaces `duplexify`. See also [duplexer replacements](./duplexer.md).
+See also [duplexer replacements](./duplexer.md).
 
 <!-- prettier-ignore -->
 ```ts
@@ -73,9 +67,9 @@ Duplex.from({ // [!code ++]
 
 Requires Node.js ≥ 16.8.0 for `Duplex.from`.
 
-## `ms.through()` replacement
+## `miss.through`
 
-Replaces `through2`. See also [through replacements](./through.md).
+See also [through replacements](./through.md).
 
 <!-- prettier-ignore -->
 ```ts
@@ -93,9 +87,9 @@ new Transform({ // [!code ++]
 }) // [!code ++]
 ```
 
-## `ms.concat()` replacement
+## `miss.concat`
 
-Replaces `concat-stream`. See also [get-stream replacements](./get-stream.md).
+See also [get-stream replacements](./get-stream.md).
 
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -106,13 +100,11 @@ const data = await buffer(stream) // [!code ++]
 fn(data) // [!code ++]
 ```
 
-Unlike `concat-stream`, which adapts its output to the input type, `buffer` always returns a `Buffer`. `node:stream/consumers` also exports `text`, `json`, and `arrayBuffer` for those cases.
+Unlike `miss.concat`, which adapts its output to the input type, `buffer` always returns a `Buffer`. `node:stream/consumers` also exports `text`, `json`, and `arrayBuffer` for those cases.
 
 Requires Node.js ≥ 16.7.0 for `node:stream/consumers`.
 
-## `ms.finished()` replacement
-
-Replaces `end-of-stream`.
+## `miss.finished`
 
 ```ts
 import miss from 'mississippi' // [!code --]
@@ -124,9 +116,7 @@ await finished(stream) // [!code ++]
 
 For callback-style usage, use [`stream.finished`](https://nodejs.org/api/stream.html#streamfinishedstream-options-callback).
 
-## `ms.from()` replacement
-
-Replaces `from2`.
+## `miss.from`
 
 <!-- prettier-ignore -->
 ```ts
@@ -142,9 +132,7 @@ Readable.from( // [!code ++]
 ) // [!code ++]
 ```
 
-## `ms.to()` replacement
-
-Replaces `flush-write-stream`.
+## `miss.to`
 
 <!-- prettier-ignore -->
 ```ts
@@ -166,9 +154,7 @@ new Writable({ // [!code ++]
 }) // [!code ++]
 ```
 
-## `ms.parallel()` replacement
-
-Replaces `parallel-transform`.
+## `miss.parallel`
 
 <!-- prettier-ignore -->
 ```ts
@@ -181,6 +167,6 @@ stream.pipe( // [!code --]
 stream.map((data) => fn(data), { concurrency: 10 }) // [!code ++]
 ```
 
-Like `parallel-transform`, `map` preserves the order of the input stream.
+Like `miss.parallel`, `map` preserves the order of the input stream.
 
 Requires Node.js >= 17.4.0 for `Readable.prototype.map`.

--- a/docs/modules/mississippi.md
+++ b/docs/modules/mississippi.md
@@ -183,4 +183,4 @@ stream.map((data) => fn(data), { concurrency: 10 }) // [!code ++]
 
 Like `parallel-transform`, `map` preserves the order of the input stream.
 
-Requires Node.js ≥ 17.4.0 for `Readable.prototype.map`.
+Requires Node.js >= 17.4.0 for `Readable.prototype.map`.

--- a/docs/modules/mississippi.md
+++ b/docs/modules/mississippi.md
@@ -1,0 +1,186 @@
+---
+description: Modern alternatives to the mississippi package
+---
+ 
+# Replacements for `mississippi`
+ 
+`mississippi` is a facade that re-exports existing stream packages. Replace each export with the corresponding native `node:stream` API (or import the underlying package directly if you still need it).
+ 
+## `ms.pipe()` replacement
+ 
+Replaces `pump`.
+ 
+```ts
+import miss from 'mississippi' // [!code --]
+import { pipeline } from 'node:stream/promises' // [!code ++]
+ 
+miss.pipe(s1, s2, s3, cb) // [!code --]
+await pipeline(s1, s2, s3) // [!code ++]
+```
+ 
+For callback-style usage, use [`stream.pipeline`](https://nodejs.org/api/stream.html#streampipelinestreams-callback).
+ 
+## `ms.each()` replacement
+ 
+Replaces `stream-each`.
+ 
+<!-- prettier-ignore -->
+```ts
+import miss from 'mississippi' // [!code --]
+ 
+miss.each(stream, (data, cb) => { // [!code --]
+  fn(data) // [!code --]
+  cb() // [!code --]
+}) // [!code --]
+ 
+for await (const data of stream) { // [!code ++]
+  fn(data) // [!code ++]
+} // [!code ++]
+```
+ 
+Note that `stream-each` reports stream errors through its done callback, while `for await` throws them — wrap the loop in `try/catch` to handle errors.
+ 
+## `ms.pipeline()` replacement
+ 
+Replaces `pumpify`.
+ 
+```ts
+import miss from 'mississippi' // [!code --]
+import { compose } from 'node:stream' // [!code ++]
+ 
+miss.pipeline(s1, s2, s3) // [!code --]
+compose(s1, s2, s3) // [!code ++]
+```
+ 
+Requires Node.js ≥ 16.9.0.
+ 
+## `ms.duplex()` replacement
+ 
+Replaces `duplexify`. See also [duplexer replacements](./duplexer.md).
+ 
+<!-- prettier-ignore -->
+```ts
+import miss from 'mississippi' // [!code --]
+import { Duplex } from 'node:stream' // [!code ++]
+ 
+miss.duplex(writableStream, readableStream) // [!code --]
+ 
+Duplex.from({ // [!code ++]
+  writable: writableStream, // [!code ++]
+  readable: readableStream // [!code ++]
+}) // [!code ++]
+```
+ 
+Requires Node.js ≥ 16.8.0 for `Duplex.from`.
+ 
+## `ms.through()` replacement
+ 
+Replaces `through2`. See also [through replacements](./through.md).
+ 
+<!-- prettier-ignore -->
+```ts
+import miss from 'mississippi' // [!code --]
+import { Transform } from 'node:stream' // [!code ++]
+ 
+miss.through((chunk, enc, cb) => { // [!code --]
+  cb(null, fn(chunk)) // [!code --]
+}) // [!code --]
+ 
+new Transform({ // [!code ++]
+  transform(chunk, encoding, callback) { // [!code ++]
+    callback(null, fn(chunk)) // [!code ++]
+  } // [!code ++]
+}) // [!code ++]
+```
+ 
+## `ms.concat()` replacement
+ 
+Replaces `concat-stream`. See also [get-stream replacements](./get-stream.md).
+ 
+```ts
+import miss from 'mississippi' // [!code --]
+import { buffer } from 'node:stream/consumers' // [!code ++]
+ 
+stream.pipe(miss.concat((data) => fn(data))) // [!code --]
+const data = await buffer(stream) // [!code ++]
+fn(data) // [!code ++]
+```
+ 
+Unlike `concat-stream`, which adapts its output to the input type, `buffer` always returns a `Buffer`. `node:stream/consumers` also exports `text`, `json`, and `arrayBuffer` for those cases.
+ 
+Requires Node.js ≥ 16.7.0 for `node:stream/consumers`.
+ 
+## `ms.finished()` replacement
+ 
+Replaces `end-of-stream`.
+ 
+```ts
+import miss from 'mississippi' // [!code --]
+import { finished } from 'node:stream/promises' // [!code ++]
+ 
+miss.finished(stream, cb) // [!code --]
+await finished(stream) // [!code ++]
+```
+ 
+For callback-style usage, use [`stream.finished`](https://nodejs.org/api/stream.html#streamfinishedstream-options-callback).
+ 
+## `ms.from()` replacement
+ 
+Replaces `from2`.
+ 
+<!-- prettier-ignore -->
+```ts
+import miss from 'mississippi' // [!code --]
+import { Readable } from 'node:stream' // [!code ++]
+ 
+miss.from((size, cb) => cb(null, chunk)) // [!code --]
+ 
+Readable.from( // [!code ++]
+  (async function* () { // [!code ++]
+    yield chunk // [!code ++]
+  })() // [!code ++]
+) // [!code ++]
+```
+ 
+## `ms.to()` replacement
+ 
+Replaces `flush-write-stream`.
+ 
+<!-- prettier-ignore -->
+```ts
+import miss from 'mississippi' // [!code --]
+import { Writable } from 'node:stream' // [!code ++]
+ 
+miss.to( // [!code --]
+  (chunk, enc, cb) => cb(), // [!code --]
+  (cb) => cb() // [!code --]
+) // [!code --]
+ 
+new Writable({ // [!code ++]
+  write(chunk, encoding, callback) { // [!code ++]
+    callback() // [!code ++]
+  }, // [!code ++]
+  final(callback) { // [!code ++]
+    callback() // [!code ++]
+  } // [!code ++]
+}) // [!code ++]
+```
+ 
+## `ms.parallel()` replacement
+ 
+Replaces `parallel-transform`.
+ 
+<!-- prettier-ignore -->
+```ts
+import miss from 'mississippi' // [!code --]
+ 
+stream.pipe( // [!code --]
+  miss.parallel(10, (data, cb) => cb(null, fn(data))) // [!code --]
+) // [!code --]
+ 
+stream.map((data) => fn(data), { concurrency: 10 }) // [!code ++]
+```
+ 
+Like `parallel-transform`, `map` preserves the order of the input stream.
+ 
+Requires Node.js ≥ 17.4.0 for `Readable.prototype.map`.

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2274,6 +2274,12 @@
       "replacements": ["util.parseArgs", "mri"],
       "url": {"type": "e18e", "id": "parseargs"}
     },
+    "mississippi": {
+      "type": "module",
+      "moduleName": "mississippi",
+      "replacements": ["node:stream"],
+      "url": {"type": "e18e", "id": "mississippi"}
+    },
     "mkdirp": {
       "type": "module",
       "moduleName": "mkdirp",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
closes: #653

### 📚 Description

adds `mississippi` to the preferred manifest so tooling can recommend dropping it in favor of native `node:stream` APIs
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
