### PR TITLE
feat(native): add tmp to replacements

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -1603,6 +1603,18 @@
       "url": {"type": "node", "id": "api/fs.html#promises-api"},
       "nodeFeatureId": {"moduleName": "fs"}
     },
+    "fs.promises.mkdtemp": {
+      "id": "fs.promises.mkdtemp",
+      "type": "native",
+      "nodeFeatureId": {
+        "moduleName": "node:fs/promises",
+        "exportName": "mkdtemp"
+      },
+      "url": {
+        "type": "node",
+        "id": "api/fs.html#fspromisesmkdtempprefix-options"
+      }
+    },
     "fs.promises.rm": {
       "id": "fs.promises.rm",
       "type": "native",
@@ -2908,6 +2920,11 @@
       "type": "module",
       "moduleName": "symbol.prototype.description",
       "replacements": ["Symbol.prototype.description"]
+    },
+    "tmp": {
+      "type": "module",
+      "moduleName": "tmp",
+      "replacements": ["fs.promises.mkdtemp"]
     },
     "to-buffer": {
       "type": "module",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
closes: #716

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
adds `fs.mkdtemp` to native manifest as replacement for the `tmp` package.
<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
