### PR TITLE
feat(preferred): add object-identity as an object-hash replacement

### DIFF
--- a/docs/modules/object-hash.md
+++ b/docs/modules/object-hash.md
@@ -18,6 +18,22 @@ const h = objectHash(obj) // [!code --]
 const h = hash(obj) // [!code ++]
 ```
 
+## `object-identity`
+
+[`object-identity`](https://github.com/maraisr/object-identity) canonicalizes any value into a stable identity string. It's deep, cycle-safe, and dependency-free, and it's a great fit for deriving a deterministic key or comparing structural equality. For most uses of `object-hash`, it should serve you well.
+
+It returns a stable identity rather than a cryptographic hash. If you specifically need a hash digest, follow one of the examples below.
+
+Example:
+
+```ts
+import objectHash from 'object-hash' // [!code --]
+import { identify } from 'object-identity' // [!code ++]
+
+const id = objectHash(obj) // [!code --]
+const id = identify(obj) // [!code ++]
+```
+
 ## Web Crypto
 
 Use the standard [`SubtleCrypto.digest`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest) available in modern runtimes. Pair it with a stable serializer (e.g., [`safe-stable-stringify`](https://github.com/BridgeAR/safe-stable-stringify), [`object-identity`](https://github.com/maraisr/object-identity)) to ensure deterministic key ordering.

--- a/docs/modules/object-hash.md
+++ b/docs/modules/object-hash.md
@@ -20,16 +20,16 @@ const h = hash(obj) // [!code ++]
 
 ## Web Crypto
 
-Use the standard [`SubtleCrypto.digest`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest) available in modern runtimes. Pair it with a stable serializer (e.g., [`safe-stable-stringify`](https://github.com/BridgeAR/safe-stable-stringify)) to ensure deterministic key ordering.
+Use the standard [`SubtleCrypto.digest`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest) available in modern runtimes. Pair it with a stable serializer (e.g., [`safe-stable-stringify`](https://github.com/BridgeAR/safe-stable-stringify), [`object-identity`](https://github.com/maraisr/object-identity)) to ensure deterministic key ordering.
 
 Example:
 
 ```ts
 import objectHash from 'object-hash' // [!code --]
-import stringify from 'safe-stable-stringify' // [!code ++]
+import { identify } from 'object-identity' // [!code ++]
 
 const h = objectHash(obj, { algorithm: 'sha256' }) // [!code --]
-const data = new TextEncoder().encode(stringify(obj)) // [!code ++]
+const data = new TextEncoder().encode(identify(obj)) // [!code ++]
 const buf = await crypto.subtle.digest('SHA-256', data) // [!code ++]
 const h = Array.from(new Uint8Array(buf)) // [!code ++]
   .map((b) => b.toString(16).padStart(2, '0')) // [!code ++]
@@ -46,10 +46,10 @@ Example:
 
 ```ts
 import objectHash from 'object-hash' // [!code --]
-import stringify from 'safe-stable-stringify' // [!code ++]
+import { identify } from 'object-identity' // [!code ++]
 
 const h = objectHash(obj, { algorithm: 'sha256' }) // [!code --]
 const hasher = new CryptoHasher('sha256') // [!code ++]
-hasher.update(stringify(obj)) // [!code ++]
+hasher.update(identify(obj)) // [!code ++]
 const h = hasher.digest('hex') // [!code ++]
 ```

--- a/docs/modules/object-hash.md
+++ b/docs/modules/object-hash.md
@@ -36,7 +36,7 @@ const id = identify(obj) // [!code ++]
 
 ## Web Crypto
 
-Use the standard [`SubtleCrypto.digest`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest) available in modern runtimes. Pair it with a stable serializer (e.g., [`safe-stable-stringify`](https://github.com/BridgeAR/safe-stable-stringify), [`object-identity`](https://github.com/maraisr/object-identity)) to ensure deterministic key ordering.
+Use the standard [`SubtleCrypto.digest`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest) available in modern runtimes. Pair it with a stable serializer (e.g., [`object-identity`](https://github.com/maraisr/object-identity)) to ensure deterministic key ordering.
 
 Example:
 

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2359,7 +2359,12 @@
     "object-hash": {
       "type": "module",
       "moduleName": "object-hash",
-      "replacements": ["ohash", "crypto", "Bun.CryptoHasher"],
+      "replacements": [
+        "object-identity",
+        "ohash",
+        "crypto",
+        "Bun.CryptoHasher"
+      ],
       "url": {"type": "e18e", "id": "object-hash"}
     },
     "object-path": {
@@ -3369,6 +3374,11 @@
       "id": "npm-run-all2",
       "type": "documented",
       "replacementModule": "npm-run-all2"
+    },
+    "object-identity": {
+      "id": "object-identity",
+      "type": "documented",
+      "replacementModule": "object-identity"
     },
     "obug": {"id": "obug", "type": "documented", "replacementModule": "obug"},
     "ofetch": {


### PR DESCRIPTION
### 🔗 Linked issue

There isn't a dedicated open issue for this one, it builds on the existing `object-hash` replacement page (prior context in #245). Happy to open a tracking issue first if you'd rather discuss it there.

### 📚 Description

This PR suggests [`object-identity`](https://github.com/maraisr/object-identity) as another replacement option for `object-hash`.

- adds `object-identity` to the `object-hash` mapping in `preferred.json` (as a `documented` replacement, alongside `ohash`), and
- updates the examples to use it as the stable serializer.

Full disclosure: I'm the author of `object-identity`, so please take this as you will. I've tried to keep every claim backed by numbers and to be honest about the trade-offs, very happy to adjust or drop anything.

#### Why it fits here

`object-identity` canonicalizes any value into a stable identity string, exactly the lib you reach for when you need a deterministic key to hash or to compare. It's deep and cycle-safe by default, and it's tiny.

**Smaller** — both are zero-dependency; minified + gzipped:

| package | min + gzip |
| --- | --- |
| `object-identity` | **~555 B** |
| `safe-stable-stringify` | ~2.47 KB |

That's roughly 4.5× smaller.

**Faster** — I am using my benchmarks for these two libraries (ops/sec, higher is better):

| workload | `object-identity` | `safe-stable-stringify` |
| --- | --- | --- |
| simple | **910,961** | 593,432 |
| deep | **115,162** | 73,438 |
| deep circular | **175,990** | 138,163 |
| big | 7,095 | **7,377** |
| leafy | **43,393** | 20,510 |

So it's ahead on most cases (≈1.3×–2.1×) and about line-ball on the wide "big" object, where `safe-stable-stringify` is marginally quicker (room for improvement).

> I took heavy inspiration from `safe-stable-stringify`'s test-suite, and pass all of them for their default configuration. So this is very much a drop-in replacement. 

#### Trade-offs / what it doesn't do

`object-identity` is deliberately opinionated: it always produces a canonical, cycle-safe identity and exposes no options, so it doesn't cover some of `safe-stable-stringify`'s options, for example:

- a custom key comparator / toggling `deterministic`
- customising the circular-reference value (or throwing on cycles)
- `maximumDepth` / `maximumBreadth` limits
- a `replacer`, indentation / pretty-printing, and BigInt handling

It also emits an internal identity string rather than valid, human-readable JSON. In practice, for what this utility is usually used for, is for deriving a stable key to feed a hash, or checking structural equality. None of those tend to matter; you just want the same input to map to the same output. If you specifically need canonical JSON out, a `replacer`, or pretty output, `safe-stable-stringify` remains the better tool, which is why it stays alongside.

Very open to feedback, and happy to reword, or keep this docs-only and drop the manifest entry if that sits better with how you'd like to position it. Thanks for considering it, and for maintaining this ❤️ 
