### PR TITLE
feat: expose util subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,12 @@
         "default": "./dist/main.js"
       }
     },
+    "./util": {
+      "import": {
+        "types": "./dist/util.d.ts",
+        "default": "./dist/util.js"
+      }
+    },
     "./dist/util.js": {
       "import": {
         "types": "./dist/util.d.ts",


### PR DESCRIPTION
### 🔗 Linked issue

None (Perf related)

### 📚 Description

This PR adds a stable `module-replacements/util` export for `resolveDocUrl`, avoiding the root import that pulls manifests into client bundles.

This results in a smaller bundle if you dont need the manifest, saving ~26kB gzipped.

### Alternatives

Use `dist/utils.js` which works today but does not feel like it part of the public API contract.