### PR TITLE
perf: mark package as side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "This package provides a set of manifests which each define a mapping of JS modules to their suggested replacements.",
   "version": "1.0.0",
   "main": "./dist/main.js",
+  "sideEffects": false,
   "scripts": {
     "build": "pnpm clean && pnpm build:types",
     "build:types": "tsc",


### PR DESCRIPTION
### 🔗 Linked issue

Supersedes #751 

### 📚 Description

Set `sideEffects` to `false`. This lets bundlers like rolldown tree-shake unused manifest JSON when consumers import helpers from the root module-replacements entry.

For `resolveDocUrl`, the root import drops from about 26.6 KB gzipped to about 242 B gzipped.
