### PR TITLE
fix: move define-properties to preferred manifest

### DIFF
--- a/docs/modules/define-properties.md
+++ b/docs/modules/define-properties.md
@@ -11,22 +11,20 @@ description: Native alternatives to the define-properties package for defining m
 Example:
 
 ```ts
-import defineProperties from 'define-properties'
+import defineProperties from 'define-properties' // [!code --]
 
 const obj = {}
-
-defineProperties(obj, {
-  enabled: true
-})
-
-Object.defineProperties(obj, {
+const descriptors = {
   enabled: {
     configurable: true,
     enumerable: false,
     value: true,
     writable: false
   }
-})
+}
+
+defineProperties(obj, { enabled: true }) // [!code --]
+Object.defineProperties(obj, descriptors) // [!code ++]
 ```
 
 `define-properties` also skips existing properties unless a matching predicate returns `true`. If your code relies on that behavior, keep the condition outside the descriptor map when migrating:

--- a/docs/modules/define-properties.md
+++ b/docs/modules/define-properties.md
@@ -1,0 +1,47 @@
+---
+description: Native alternatives to the define-properties package for defining multiple object properties
+---
+
+# Replacements for `define-properties`
+
+## `Object.defineProperties` (native)
+
+[`Object.defineProperties`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties) can define multiple properties on an object without an extra dependency.
+
+Example:
+
+```ts
+import defineProperties from 'define-properties'
+
+const obj = {}
+
+defineProperties(obj, {
+  enabled: true
+})
+
+Object.defineProperties(obj, {
+  enabled: {
+    configurable: true,
+    enumerable: false,
+    value: true,
+    writable: false
+  }
+})
+```
+
+`define-properties` also skips existing properties unless a matching predicate returns `true`. If your code relies on that behavior, keep the condition outside the descriptor map when migrating:
+
+```ts
+const descriptors = {
+  enabled: {
+    configurable: true,
+    enumerable: false,
+    value: true,
+    writable: false
+  }
+}
+
+if (!Object.hasOwn(obj, 'enabled') || shouldOverrideEnabled()) {
+  Object.defineProperties(obj, descriptors)
+}
+```

--- a/docs/modules/define-properties.md
+++ b/docs/modules/define-properties.md
@@ -30,6 +30,8 @@ Object.defineProperties(obj, descriptors) // [!code ++]
 `define-properties` also skips existing properties unless a matching predicate returns `true`. If your code relies on that behavior, keep the condition outside the descriptor map when migrating:
 
 ```ts
+import defineProperties from 'define-properties' // [!code --]
+
 const descriptors = {
   enabled: {
     configurable: true,
@@ -39,7 +41,9 @@ const descriptors = {
   }
 }
 
+defineProperties(obj, { enabled: true }, { enabled: shouldOverrideEnabled }) // [!code --]
 if (!Object.hasOwn(obj, 'enabled') || shouldOverrideEnabled()) {
-  Object.defineProperties(obj, descriptors)
+  // [!code ++]
+  Object.defineProperties(obj, descriptors) // [!code ++]
 }
 ```

--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2131,11 +2131,6 @@
       "moduleName": "define-data-property",
       "replacements": ["Object.defineProperty"]
     },
-    "define-properties": {
-      "type": "module",
-      "moduleName": "define-properties",
-      "replacements": ["Object.defineProperties"]
-    },
     "define-property": {
       "type": "module",
       "moduleName": "define-property",

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -220,6 +220,11 @@
       "replacements": ["dequal", "util.isDeepStrictEqual", "Bun.deepEquals"],
       "url": {"type": "e18e", "id": "deep-equal"}
     },
+    "define-properties": {
+      "type": "module",
+      "moduleName": "define-properties",
+      "replacements": ["Object.defineProperties"]
+    },
     "depcheck": {
       "type": "module",
       "moduleName": "depcheck",
@@ -2916,6 +2921,18 @@
       "url": {
         "type": "mdn",
         "id": "Web/JavaScript/Reference/Global_Objects/Intl/Segmenter"
+      }
+    },
+    "Object.defineProperties": {
+      "id": "Object.defineProperties",
+      "type": "native",
+      "url": {
+        "type": "mdn",
+        "id": "Web/JavaScript/Reference/Global_Objects/Object/defineProperties"
+      },
+      "webFeatureId": {
+        "featureId": "object-object",
+        "compatKey": "javascript.builtins.Object.defineProperties"
       }
     },
     "Promise": {

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -223,7 +223,8 @@
     "define-properties": {
       "type": "module",
       "moduleName": "define-properties",
-      "replacements": ["Object.defineProperties"]
+      "replacements": ["Object.defineProperties"],
+      "url": {"type": "e18e", "id": "define-properties"}
     },
     "depcheck": {
       "type": "module",


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/es-tooling/eslint-plugin-depend/issues/35

### 📚 Description

Moves `define-properties` from the native manifest to the preferred manifest because it is not always a direct native drop-in for `Object.defineProperties`.

This also adds a docs page for the preferred entry, with the distinction that `Object.defineProperties` is enough when callers only need to define descriptors, while `define-properties` has extra behavior around existing properties and predicate-controlled overrides.

Checks:
`pnpm lint`