### PR TITLE
chore: update node script to accept `miscs`

### DIFF
--- a/scripts/update-engines-node.ts
+++ b/scripts/update-engines-node.ts
@@ -44,6 +44,16 @@ interface DocumentedNodeClass {
   classMethods?: Array<DocumentedNodeClassMethod | DocumentedUnknownNode>;
 }
 
+interface DocumentedNodeMisc {
+  type: 'misc';
+  name: string;
+  modules?: Array<DocumentedNodeModule | DocumentedUnknownNode>;
+  classes?: Array<DocumentedNodeClass | DocumentedUnknownNode>;
+  properties?: Array<DocumentedNodeProperty>;
+  methods?: Array<DocumentedNodeMethod | DocumentedUnknownNode>;
+  miscs?: Array<DocumentedNodeMisc | DocumentedUnknownNode>;
+}
+
 interface DocumentedNodeGlobal {
   type: 'global';
   name: string;
@@ -52,6 +62,7 @@ interface DocumentedNodeGlobal {
   classes?: Array<DocumentedNodeClass | DocumentedUnknownNode>;
   properties?: Array<DocumentedNodeProperty>;
   methods?: Array<DocumentedNodeMethod | DocumentedUnknownNode>;
+  miscs?: Array<DocumentedNodeMisc | DocumentedUnknownNode>;
 }
 
 interface DocumentedNodeModule {
@@ -63,6 +74,7 @@ interface DocumentedNodeModule {
   classes?: Array<DocumentedNodeClass | DocumentedUnknownNode>;
   properties?: Array<DocumentedNodeProperty>;
   methods?: Array<DocumentedNodeMethod | DocumentedUnknownNode>;
+  miscs?: Array<DocumentedNodeMisc | DocumentedUnknownNode>;
   globals?: Array<DocumentedNodeGlobal | DocumentedUnknownNode>;
 }
 
@@ -127,40 +139,46 @@ function earliestVersion(versions: string[]): string {
 }
 
 function findExportVersion(
-  module: DocumentedNodeModule | DocumentedNodeGlobal,
+  module: DocumentedNodeModule | DocumentedNodeGlobal | DocumentedNodeMisc,
   exportName: string,
-  lastIntroducedIn?: string
+  lastIntroducedIn: string | null
 ): string | null {
-  const introducedIn =
-    module.introduced_in?.replace(/^v/, '') ?? lastIntroducedIn;
+  let introducedIn: string | null = lastIntroducedIn;
+  if (module.type !== 'misc' && module.introduced_in) {
+    introducedIn = module.introduced_in.replace(/^v/, '');
+  }
 
   for (const item of module.methods ?? []) {
     if (item.type === 'method' && item.name === exportName) {
-      return item.meta?.added
-        ? earliestVersion(item.meta.added)
-        : (introducedIn ?? null);
+      return item.meta?.added ? earliestVersion(item.meta.added) : introducedIn;
     }
   }
 
   for (const item of module.properties ?? []) {
     if (item.name === exportName) {
-      return item.meta?.added
-        ? earliestVersion(item.meta.added)
-        : (introducedIn ?? null);
+      return item.meta?.added ? earliestVersion(item.meta.added) : introducedIn;
     }
   }
 
   for (const item of module.classes ?? []) {
-    if (item.type === 'class' && item.name === exportName) {
-      return item.meta?.added
-        ? earliestVersion(item.meta.added)
-        : (introducedIn ?? null);
+    if (
+      item.type === 'class' &&
+      (item.name === exportName || item.name.endsWith(`.${exportName}`))
+    ) {
+      return item.meta?.added ? earliestVersion(item.meta.added) : introducedIn;
     }
   }
 
   for (const sub of module.modules ?? []) {
     if (sub.type === 'module') {
       const found = findExportVersion(sub, exportName, introducedIn);
+      if (found) return found;
+    }
+  }
+
+  for (const misc of module.miscs ?? []) {
+    if (misc.type === 'misc') {
+      const found = findExportVersion(misc, exportName, introducedIn);
       if (found) return found;
     }
   }
@@ -228,7 +246,7 @@ async function getNodeVersion(
     return null;
   }
 
-  return findExportVersion(root, exportName);
+  return findExportVersion(root, exportName, null);
 }
 
 async function updateReplacementNodeEngine(


### PR DESCRIPTION
The node JSON has `miscs` - yet another sub-object of exports. So we
need to traverse those too in order to get hold of things like
`stream.Readable`.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
