### PR TITLE
feat(native): add buffer-alloc-unsafe to replacements

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -549,6 +549,15 @@
         "compatKey": "javascript.builtins.BigInt"
       }
     },
+    "Buffer.allocUnsafe": {
+      "id": "Buffer.allocUnsafe",
+      "type": "native",
+      "url": {
+        "type": "node",
+        "id": "api/buffer.html#static-method-bufferallocunsafesize"
+      },
+      "nodeFeatureId": {"moduleName": "buffer"}
+    },
     "Buffer.from": {
       "id": "Buffer.from",
       "type": "native",
@@ -2084,6 +2093,11 @@
       "replacements": ["atob"]
     },
     "btoa": {"type": "module", "moduleName": "btoa", "replacements": ["btoa"]},
+    "buffer-alloc-unsafe": {
+      "type": "module",
+      "moduleName": "buffer-alloc-unsafe",
+      "replacements": ["Buffer.allocUnsafe"]
+    },
     "buffer-crc32": {
       "type": "module",
       "moduleName": "buffer-crc32",


### PR DESCRIPTION
### 🔗 Linked issue

closes: #784
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

adds `buffer-alloc-unsafe` to replacements
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
